### PR TITLE
POC implementation for converting a stream of BSON documents to a pyarrow.Table instance

### DIFF
--- a/bindings/python/pymongoarrow/bson.pyi
+++ b/bindings/python/pymongoarrow/bson.pyi
@@ -64,3 +64,5 @@ def process_bson_stream(bson_stream, context):
                 else:
                     raise TypeError('unknown ftype {}'.format(ftype))
         doc = bson_reader_read(stream_reader, &reached_eof)
+
+    bson_reader_destroy(stream_reader)

--- a/bindings/python/pymongoarrow/bson.pyi
+++ b/bindings/python/pymongoarrow/bson.pyi
@@ -22,6 +22,7 @@ def process_bson_stream(bson_stream, context):
     cdef bson_iter_t doc_iter
     cdef const char* key
     cdef bson_type_t value_t
+    cdef uint64_t count = 0
 
     builder_map = context.builder_map
     type_map = context.type_map
@@ -64,6 +65,10 @@ def process_bson_stream(bson_stream, context):
                             builder.append_null()
                     else:
                         raise TypeError('unknown ftype {}'.format(ftype))
+            count += 1
+            for _, builder in builder_map.items():
+                if len(builder) != count:
+                    builder.append_null()
             doc = bson_reader_read(stream_reader, &reached_eof)
     finally:
         bson_reader_destroy(stream_reader)

--- a/bindings/python/pymongoarrow/bson.pyi
+++ b/bindings/python/pymongoarrow/bson.pyi
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-cdef const bson_t* bson_reader_read_safe(bson_reader_t* stream_reader, cbool* reached_eof) except *:
+cdef const bson_t* bson_reader_read_safe(bson_reader_t* stream_reader, cbool* reached_eof) except? NULL:
     cdef const bson_t* doc = bson_reader_read(stream_reader, reached_eof)
     if doc == NULL and dereference(reached_eof) == False:
         raise RuntimeError("Could not read BSON stream")

--- a/bindings/python/pymongoarrow/bson.pyi
+++ b/bindings/python/pymongoarrow/bson.pyi
@@ -40,7 +40,7 @@ def process_bson_stream(bson_stream, context):
             if doc == NULL:
                 break
             if not bson_iter_init(&doc_iter, doc):
-                raise RuntimeError
+                raise RuntimeError("Could not read BSON document")
             while bson_iter_next(&doc_iter):
                 key = bson_iter_key(&doc_iter)
                 if key in builder_map:

--- a/bindings/python/pymongoarrow/bson.pyi
+++ b/bindings/python/pymongoarrow/bson.pyi
@@ -1,0 +1,66 @@
+# Copyright 2021-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def process_bson_stream(bson_stream, context):
+    cdef const uint8_t* docstream = <const uint8_t *>bson_stream
+    cdef size_t length = <size_t>PyBytes_Size(bson_stream)
+    cdef bson_reader_t* stream_reader = bson_reader_new_from_data(docstream, length)
+    cdef cbool reached_eof = False
+    cdef const bson_t * doc = bson_reader_read(stream_reader, & reached_eof)
+    cdef bson_iter_t doc_iter
+    cdef const char* key
+    cdef bson_type_t value_t
+
+    builder_map = context.builder_map
+    type_map = context.type_map
+
+    while doc != NULL:
+        if not bson_iter_init(&doc_iter, doc):
+            raise RuntimeError
+        while bson_iter_next(&doc_iter):
+            key = bson_iter_key(&doc_iter)
+            if key in builder_map:
+                builder = builder_map[key]
+                ftype = type_map[key]
+                value_t = bson_iter_type(&doc_iter)
+                if ftype == _BsonArrowTypes.int32:
+                    if value_t == BSON_TYPE_INT32:
+                        builder.append(bson_iter_int32(&doc_iter))
+                    else:
+                        builder.append_null()
+                elif ftype == _BsonArrowTypes.int64:
+                    if (value_t == BSON_TYPE_INT64 or
+                            value_t == BSON_TYPE_BOOL or
+                            value_t == BSON_TYPE_DOUBLE or
+                            value_t == BSON_TYPE_INT32):
+                        builder.append(bson_iter_as_int64(&doc_iter))
+                    else:
+                        builder.append_null()
+                elif ftype == _BsonArrowTypes.double:
+                    if (value_t == BSON_TYPE_DOUBLE or
+                            value_t == BSON_TYPE_BOOL or
+                            value_t == BSON_TYPE_INT32 or
+                            value_t == BSON_TYPE_INT64):
+                        builder.append(bson_iter_as_double(&doc_iter))
+                    else:
+                        builder.append_null()
+                elif ftype == _BsonArrowTypes.datetime:
+                    if value_t == BSON_TYPE_DATE_TIME:
+                        builder.append(bson_iter_date_time(&doc_iter))
+                    else:
+                        builder.append_null()
+                else:
+                    raise TypeError('unknown ftype {}'.format(ftype))
+        doc = bson_reader_read(stream_reader, &reached_eof)

--- a/bindings/python/pymongoarrow/builders.pyi
+++ b/bindings/python/pymongoarrow/builders.pyi
@@ -13,26 +13,25 @@
 # limitations under the License.
 
 
-cdef class _BuilderBase:
+cdef class _ArrayBuilderBase:
     def append_values(self, values):
         for value in values:
             self.append(value)
 
-    @property
-    def null_count(self):
-        return self.builder.get().null_count()
 
-    def __len__(self):
-        return self.builder.get().length()
-
-
-cdef class Int32Builder(_BuilderBase):
+cdef class Int32Builder(_ArrayBuilderBase):
     cdef:
         shared_ptr[CInt32Builder] builder
 
     def __cinit__(self, MemoryPool memory_pool=None):
         cdef CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
         self.builder.reset(new CInt32Builder(pool))
+
+    def append_null(self):
+        self.builder.get().AppendNull()
+
+    def __len__(self):
+        return self.builder.get().length()
 
     def append(self, value):
         if value is None or value is np.nan:
@@ -52,13 +51,19 @@ cdef class Int32Builder(_BuilderBase):
         return self.builder
 
 
-cdef class Int64Builder(_BuilderBase):
+cdef class Int64Builder(_ArrayBuilderBase):
     cdef:
         shared_ptr[CInt64Builder] builder
 
     def __cinit__(self, MemoryPool memory_pool=None):
         cdef CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
         self.builder.reset(new CInt64Builder(pool))
+
+    def append_null(self):
+        self.builder.get().AppendNull()
+
+    def __len__(self):
+        return self.builder.get().length()
 
     def append(self, value):
         if value is None or value is np.nan:
@@ -78,13 +83,19 @@ cdef class Int64Builder(_BuilderBase):
         return self.builder
 
 
-cdef class DoubleBuilder(_BuilderBase):
+cdef class DoubleBuilder(_ArrayBuilderBase):
     cdef:
         shared_ptr[CDoubleBuilder] builder
 
     def __cinit__(self, MemoryPool memory_pool=None):
         cdef CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
         self.builder.reset(new CDoubleBuilder(pool))
+
+    def append_null(self):
+        self.builder.get().AppendNull()
+
+    def __len__(self):
+        return self.builder.get().length()
 
     def append(self, value):
         if value is None or value is np.nan:
@@ -104,7 +115,7 @@ cdef class DoubleBuilder(_BuilderBase):
         return self.builder
 
 
-cdef class DatetimeBuilder(_BuilderBase):
+cdef class DatetimeBuilder(_ArrayBuilderBase):
     cdef:
         shared_ptr[CTimestampBuilder] builder
         TimestampType dtype
@@ -119,6 +130,12 @@ cdef class DatetimeBuilder(_BuilderBase):
         self.dtype = dtype
         self.builder.reset(new CTimestampBuilder(
             pyarrow_unwrap_data_type(self.dtype), pool))
+
+    def append_null(self):
+        self.builder.get().AppendNull()
+
+    def __len__(self):
+        return self.builder.get().length()
 
     def append(self, value):
         if value is None or value is np.nan:

--- a/bindings/python/pymongoarrow/builders.pyi
+++ b/bindings/python/pymongoarrow/builders.pyi
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Cython compiler directives
-# distutils: language=c++
-# cython: language_level=3
 
 cdef class _BuilderBase:
     def append_values(self, values):

--- a/bindings/python/pymongoarrow/context.py
+++ b/bindings/python/pymongoarrow/context.py
@@ -58,14 +58,6 @@ class PyMongoArrowContext:
             type_map[encoded_fname] = ftype
         return cls(schema, builder_map, type_map)
 
-    def __contains__(self, item):
-        if isinstance(item, str):
-            return item in self.schema
-        elif isinstance(item, bytes):
-            return item in self.builder_map
-        else:
-            raise TypeError('context keys are either str or bytes type')
-
     def finish(self):
         arrays = []
         names = []

--- a/bindings/python/pymongoarrow/context.py
+++ b/bindings/python/pymongoarrow/context.py
@@ -1,0 +1,59 @@
+# Copyright 2021-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pyarrow import Table
+from pymongoarrow.lib import Int32Builder, Int64Builder, DoubleBuilder, DatetimeBuilder
+from pymongoarrow.types import _get_internal_typemap, _BsonArrowTypes
+
+
+_TYPE_TO_BUILDER_CLS = {
+    _BsonArrowTypes.int32: Int32Builder,
+    _BsonArrowTypes.int64: Int64Builder,
+    _BsonArrowTypes.double: DoubleBuilder,
+    _BsonArrowTypes.datetime: DatetimeBuilder
+}
+
+
+class PyMongoArrowContext:
+    def __init__(self, schema, builder_map, type_map):
+        self.schema = schema
+        self.builder_map = builder_map
+        self.type_map = type_map
+
+    @classmethod
+    def from_schema(cls, schema):
+        builder_map = {}
+        type_map = {}
+        str_type_map = _get_internal_typemap(schema.typemap)
+        for fname, ftype in str_type_map.items():
+            builder_cls = _TYPE_TO_BUILDER_CLS[ftype]
+            encoded_fname = fname.encode('utf-8')
+            builder_map[encoded_fname] = builder_cls()   # TODO: support passing parameterized types to Builders (e.g. datetime)
+            type_map[encoded_fname] = ftype
+        return cls(schema, builder_map, type_map)
+
+    def __contains__(self, item):
+        if isinstance(item, str):
+            return item in self.schema
+        elif isinstance(item, bytes):
+            return item in self.builder_map
+        else:
+            raise TypeError('context keys are either str or bytes type')
+
+    def finish(self):
+        arrays = []
+        names = []
+        for fname, builder in self.builder_map.items():
+            arrays.append(builder.finish())
+            names.append(fname.decode('utf-8'))
+        return Table.from_arrays(arrays=arrays, names=names)

--- a/bindings/python/pymongoarrow/context.py
+++ b/bindings/python/pymongoarrow/context.py
@@ -25,13 +25,29 @@ _TYPE_TO_BUILDER_CLS = {
 
 
 class PyMongoArrowContext:
+    """A context for converting BSON-formatted data to an Arrow Table."""
     def __init__(self, schema, builder_map, type_map):
+        """Initialize the context.
+
+        :Parameters:
+          - `schema`: Instance of :class:`~pymongoarrow.schema.Schema`.
+          - `builder_map`: Mapping of utf-8-encoded field names to
+            :class:`~pymongoarrow.builders._BuilderBase` instances.
+          - `type_map`: Mapping of utf-8-encoded field names to
+            :class:`~pymongoarrow.types._BsonArrowTypes` instances.
+        """
         self.schema = schema
         self.builder_map = builder_map
         self.type_map = type_map
 
     @classmethod
     def from_schema(cls, schema):
+        """Initialize the context from a :class:`~pymongoarrow.schema.Schema`
+        instance.
+
+        :Parameters:
+          - `schema`: Instance of :class:`~pymongoarrow.schema.Schema`.
+        """
         builder_map = {}
         type_map = {}
         str_type_map = _get_internal_typemap(schema.typemap)

--- a/bindings/python/pymongoarrow/lib.pyx
+++ b/bindings/python/pymongoarrow/lib.pyx
@@ -28,6 +28,7 @@ from pymongoarrow.types import _BsonArrowTypes
 
 # Cython imports
 from cpython cimport PyBytes_Size, object
+from cython.operator cimport dereference
 from libcpp cimport bool as cbool
 from libcpp.map cimport map
 from libcpp.string cimport string

--- a/bindings/python/pymongoarrow/lib.pyx
+++ b/bindings/python/pymongoarrow/lib.pyx
@@ -17,15 +17,26 @@
 # cython: language_level=3
 
 # Stdlib imports
+import copy
 import datetime
+import enum
 
 # Python imports
 import numpy as np
 from pyarrow import timestamp
+from pymongoarrow.types import _BsonArrowTypes
 
 # Cython imports
+from cpython cimport PyBytes_Size, object
+from libcpp cimport bool as cbool
+from libcpp.map cimport map
+from libcpp.string cimport string
 from pyarrow.lib cimport *
+from pymongoarrow.libbson cimport *
 
+
+# BSON tools
+include "bson.pyi"
 
 # Utilities
 include "utils.pyi"

--- a/bindings/python/pymongoarrow/libbson/__init__.pxd
+++ b/bindings/python/pymongoarrow/libbson/__init__.pxd
@@ -112,9 +112,13 @@ cdef extern from "bson/bson.h":
 
     double bson_iter_double(const bson_iter_t *iter)
 
+    double bson_iter_as_double(const bson_iter_t *iter)
+
     int32_t bson_iter_int32(const bson_iter_t *iter)
 
     int64_t bson_iter_int64(const bson_iter_t *iter)
+
+    int64_t bson_iter_as_int64(const bson_iter_t *iter)
 
 
 # bson_reader_t API

--- a/bindings/python/pymongoarrow/libbson/__init__.pxd
+++ b/bindings/python/pymongoarrow/libbson/__init__.pxd
@@ -127,6 +127,8 @@ cdef extern from "bson/bson.h":
 
     const bson_t * bson_reader_read(bson_reader_t *reader, bint *reached_eof)
 
+    void bson_reader_destroy(bson_reader_t *reader)
+
 
 # runtime version checking API
 cdef extern from "bson/bson.h":

--- a/bindings/python/pymongoarrow/schema.py
+++ b/bindings/python/pymongoarrow/schema.py
@@ -17,7 +17,30 @@ from pymongoarrow.types import _normalize_typeid
 
 
 class Schema:
+    """A mapping of field names to data types."""
     def __init__(self, schema):
+        """Create a :class:`~pymongoarrow.schema.Schema` instance from a
+        mapping or an iterable.
+
+        If ``schema`` is a mapping, each key must be a field name and the
+        corresponding value must be the expected data type of the named field.
+        If ``schema`` is an iterable, it must be comprised entirely of 2-member
+        sub-iterables. The first member of each sub-iterable must be a field
+        name and the second value must be the corresponding data type.
+
+        Data types can be specified as pyarrow type instances (e.g.
+        an instance of :class:`pyarrow.int64`), bson types (e.g.
+        :class:`bson.Int64`), or python type identifiers (e.g. ``int``,
+        ``float``). The following data types are currently supported:
+
+          - 32-bit signed integers
+          - 64-bit signed integers
+          - 64-bit floating point integers
+          - timestamps with millisecond or second resolution
+
+        :Parameters:
+          - `schema`: A mapping or an iterable.
+        """
         if isinstance(schema, abc.Mapping):
             normed = type(self)._normalize_mapping(schema)
         elif isinstance(schema, abc.Sequence):

--- a/bindings/python/pymongoarrow/schema.py
+++ b/bindings/python/pymongoarrow/schema.py
@@ -1,0 +1,56 @@
+# Copyright 2021-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import collections.abc as abc
+
+from pymongoarrow.types import _normalize_typeid
+
+
+class Schema:
+    def __init__(self, schema):
+        if isinstance(schema, abc.Mapping):
+            normed = type(self)._normalize_mapping(schema)
+        elif isinstance(schema, abc.Sequence):
+            normed = type(self)._normalize_sequence(schema)
+        else:
+            raise ValueError('schema must be a mapping or sequence')
+        self.typemap = normed
+
+    @staticmethod
+    def _normalize_mapping(mapping):
+        normed = {}
+        for fname, ftype in mapping.items():
+            normalized_type = _normalize_typeid(ftype)
+            if normalized_type is None:
+                raise ValueError(
+                    "Unsupported type identifier {} for field {}".format(
+                        ftype, fname))
+            normed[fname] = normalized_type
+        return normed
+
+    @staticmethod
+    def _normalize_sequence(sequence):
+        normed = {}
+        for finfo in sequence:
+            try:
+                fname, ftype = finfo
+            except ValueError:
+                raise ValueError('schema must be a sequence of 2-tuples')
+            else:
+                normalized_type = _normalize_typeid(ftype)
+                if normalized_type is None:
+                    raise ValueError(
+                        "Unsupported type identifier {} for field {}".format(
+                            ftype, fname))
+                normed[fname] = normalized_type
+        return normed

--- a/bindings/python/pymongoarrow/schema.py
+++ b/bindings/python/pymongoarrow/schema.py
@@ -30,12 +30,7 @@ class Schema:
     def _normalize_mapping(mapping):
         normed = {}
         for fname, ftype in mapping.items():
-            normalized_type = _normalize_typeid(ftype)
-            if normalized_type is None:
-                raise ValueError(
-                    "Unsupported type identifier {} for field {}".format(
-                        ftype, fname))
-            normed[fname] = normalized_type
+            normed[fname] = _normalize_typeid(ftype, fname)
         return normed
 
     @staticmethod
@@ -47,10 +42,10 @@ class Schema:
             except ValueError:
                 raise ValueError('schema must be a sequence of 2-tuples')
             else:
-                normalized_type = _normalize_typeid(ftype)
-                if normalized_type is None:
-                    raise ValueError(
-                        "Unsupported type identifier {} for field {}".format(
-                            ftype, fname))
-                normed[fname] = normalized_type
+                normed[fname] = _normalize_typeid(ftype, fname)
         return normed
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.typemap == other.typemap
+        return False

--- a/bindings/python/pymongoarrow/types.py
+++ b/bindings/python/pymongoarrow/types.py
@@ -28,9 +28,6 @@ class _BsonArrowTypes(enum.Enum):
     int64 = 4
 
 
-_SUPPORTED_TYPE_IDENTIFIERS = (Int64, float, int, datetime)
-
-
 _TYPE_NORMALIZER_FACTORY = {
     Int64: lambda _: int64(),
     float: lambda _: float64(),
@@ -48,17 +45,19 @@ _TYPE_CHECKER_TO_INTERNAL_TYPE = {
 
 
 def _is_typeid_supported(typeid):
-    return typeid in _SUPPORTED_TYPE_IDENTIFIERS
+    return typeid in _TYPE_NORMALIZER_FACTORY
 
 
-def _normalize_typeid(typeid):
+def _normalize_typeid(typeid, field_name):
     if isinstance(typeid, _ArrowDataType):
         return typeid
     elif _is_typeid_supported(typeid):
         normalizer = _TYPE_NORMALIZER_FACTORY[typeid]
         return normalizer(typeid)
     else:
-        return None
+        raise ValueError(
+            "Unsupported type identifier {} for field {}".format(
+                typeid, field_name))
 
 
 def _get_internal_typemap(typemap):

--- a/bindings/python/pymongoarrow/types.py
+++ b/bindings/python/pymongoarrow/types.py
@@ -1,0 +1,72 @@
+# Copyright 2021-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime
+import enum
+
+from bson import Int64
+
+from pyarrow import timestamp, float64, int64, int32
+from pyarrow import DataType as _ArrowDataType
+import pyarrow.types as _atypes
+
+
+class _BsonArrowTypes(enum.Enum):
+    datetime = 1
+    double = 2
+    int32 = 3
+    int64 = 4
+
+
+_SUPPORTED_TYPE_IDENTIFIERS = (Int64, float, int, datetime)
+
+
+_TYPE_NORMALIZER_FACTORY = {
+    Int64: lambda _: int64(),
+    float: lambda _: float64(),
+    int: lambda _: int64(),
+    datetime: lambda _: timestamp('ms')     # TODO: add tzinfo support
+}
+
+
+_TYPE_CHECKER_TO_INTERNAL_TYPE = {
+    _atypes.is_int32: _BsonArrowTypes.int32,
+    _atypes.is_int64: _BsonArrowTypes.int64,
+    _atypes.is_float64: _BsonArrowTypes.double,
+    _atypes.is_timestamp: _BsonArrowTypes.datetime
+}
+
+
+def _is_typeid_supported(typeid):
+    return typeid in _SUPPORTED_TYPE_IDENTIFIERS
+
+
+def _normalize_typeid(typeid):
+    if isinstance(typeid, _ArrowDataType):
+        return typeid
+    elif _is_typeid_supported(typeid):
+        normalizer = _TYPE_NORMALIZER_FACTORY[typeid]
+        return normalizer(typeid)
+    else:
+        return None
+
+
+def _get_internal_typemap(typemap):
+    internal_typemap = {}
+    for fname, ftype in typemap.items():
+        for checker, internal_id in _TYPE_CHECKER_TO_INTERNAL_TYPE.items():
+            if checker(ftype):
+                internal_typemap[fname] = internal_id
+                continue
+    assert len(internal_typemap) == len(typemap)
+    return internal_typemap

--- a/bindings/python/test/test_bson.py
+++ b/bindings/python/test/test_bson.py
@@ -53,5 +53,3 @@ class TestBSONUtil(TestCase):
 
         for key, value in table_dict.items():
             self.assertEqual(value, self.as_dict[key])
-
-        print(table.to_pandas())

--- a/bindings/python/test/test_bson.py
+++ b/bindings/python/test/test_bson.py
@@ -53,3 +53,5 @@ class TestBSONUtil(TestCase):
 
         for key, value in table_dict.items():
             self.assertEqual(value, self.as_dict[key])
+
+        print(table.to_pandas())

--- a/bindings/python/test/test_bson.py
+++ b/bindings/python/test/test_bson.py
@@ -76,10 +76,8 @@ class TestValidBsonToArrowConversion(TestBsonToArrowConversionBase):
 class TestInvalidBsonToArrowConversion(TestBsonToArrowConversionBase):
     @staticmethod
     def _generate_payload(doclist):
-        payload = b''
-        for doc in doclist:
-            payload += encode(doc)
-        return payload[:-2]
+        return TestBsonToArrowConversionBase._generate_payload(
+            doclist)[:-2]
 
     def test_simple(self):
         docs = [{'_id': 1, 'data': 10},

--- a/bindings/python/test/test_bson.py
+++ b/bindings/python/test/test_bson.py
@@ -64,10 +64,11 @@ class TestValidBsonToArrowConversion(TestBsonToArrowConversionBase):
                 {'_id': 2, 'data': 20},
                 {'_id': 3},
                 {'_id': 4, 'data': 40},
-                {'foo': 1}]
+                {'foo': 1},
+                {}]
         as_dict = {
-            '_id': [1, 2, 3, 4, None],
-            'data': [10, 20, None, 40, None]}
+            '_id': [1, 2, 3, 4, None, None],
+            'data': [10, 20, None, 40, None, None]}
 
         self._run_test(docs, as_dict)
 

--- a/bindings/python/test/test_bson.py
+++ b/bindings/python/test/test_bson.py
@@ -1,0 +1,55 @@
+# Copyright 2021-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from collections import defaultdict
+from unittest import TestCase
+
+from bson import encode
+
+from pymongoarrow.context import PyMongoArrowContext
+from pymongoarrow.lib import process_bson_stream
+from pymongoarrow.schema import Schema
+from pymongoarrow.types import int32, int64
+
+
+class TestBSONUtil(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        docs = [{'_id': 1, 'data': 10},
+                {'_id': 2, 'data': 20},
+                {'_id': 3, 'data': 30},
+                {'_id': 4, 'data': 40}]
+
+        payload = b''
+        for doc in docs:
+            payload += encode(doc)
+
+        as_dict = defaultdict(list)
+        for doc in docs:
+            for key, value in doc.items():
+                as_dict[key].append(value)
+
+        cls.as_dict = as_dict
+        cls.docs = docs
+        cls.schema = Schema({'_id': int32(),
+                             'data': int64()})
+        cls.bson_stream = payload
+
+    def test_simple(self):
+        context = PyMongoArrowContext.from_schema(self.schema)
+        process_bson_stream(self.bson_stream, context)
+        table = context.finish()
+        table_dict = table.to_pydict()
+
+        for key, value in table_dict.items():
+            self.assertEqual(value, self.as_dict[key])

--- a/bindings/python/test/test_schema.py
+++ b/bindings/python/test/test_schema.py
@@ -1,0 +1,56 @@
+# Copyright 2021-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from datetime import datetime, timedelta
+from unittest import TestCase
+
+from bson import Int64
+from pyarrow import Array, timestamp, int32, int64, float64
+
+from pymongoarrow.schema import Schema
+
+
+class TestSchema(TestCase):
+    def test_initialization(self):
+        dict_schema = Schema(
+            {'field1': int, 'field2': datetime, 'field3': float})
+        list_schema = Schema(
+            [('field1', int), ('field2', datetime), ('field3', float)])
+        tuple_schema = Schema(
+            (('field1', int), ('field2', datetime), ('field3', float)))
+
+        self.assertEqual(dict_schema, list_schema)
+        self.assertEqual(dict_schema, tuple_schema)
+        self.assertEqual(
+            dict_schema.typemap,
+            {'field1': int64(), 'field2': timestamp('ms'),
+             'field3': float64()})
+
+    def test_from_py_units(self):
+        schema = Schema(
+            {'field1': int, 'field2': datetime, 'field3': float})
+        self.assertEqual(
+            schema.typemap,
+            {'field1': int64(), 'field2': timestamp('ms'),
+             'field3': float64()})
+
+    def test_from_bson_units(self):
+        schema = Schema({'field1': Int64})
+        self.assertEqual(schema.typemap, {'field1': int64()})
+
+    def test_from_arrow_units(self):
+        schema = Schema(
+            [('field1', int64()), ('field2', timestamp('s'))])
+        self.assertEqual(
+            schema.typemap,
+            {'field1': int64(), 'field2': timestamp('s')})


### PR DESCRIPTION
With this PR we can now move data from a stream of BSON documents, into Arrow arrays which can then be assembled as an Arrow Table. 

This current design is inefficient because:
1. Extensive use of Python maps. Looking up entities stored in `Schema` and `PyMongoArrowContext` objecs incurs the additional overhead of calling Python functions from C. We do this every time we need to process a field from the BSON stream so it will result in very high overhead for a large number of documents/fields. Mitigation: use `std::map` instances. instead of Python dicts.
2. Use of Python APIs for Builder classes. When appending entries via the builder APIs we are using the Cython wrapper classes around Arrow's native ArrayBuilder classes. In addition to overhead of the Python function call itself, this causes the values being appended themselves to be wrapped and unwrapped during each called to '_BaseBuilder.appendI()`. Mitigation: unwrap the native builder classes from the encapsulating Python objects (using `_BuilderBase.unwrap` methods) and operate on the native classes directly.