### PR TITLE
Public API for Pandas

### DIFF
--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -100,3 +100,58 @@ def aggregate_arrow_all(collection, pipeline, *, schema, **kwargs):
         process_bson_stream(batch, context)
 
     return context.finish()
+
+
+def find_pandas_all(collection, query, *, schema, na_value=None, **kwargs):
+    """Method that returns the results of a find query as a
+    :class:`pandas.DataFrame` instance.
+
+    :Parameters:
+      - `collection`: Instance of :class:`~pymongo.collection.Collection`.
+        against which to run the ``find`` operation.
+      - `query`: A mapping containing the query to use for the find operation.
+      - `schema`: Instance of :class:`~pymongoarrow.schema.Schema`.
+      - `na_value`: Scalar or mapping containing the value to use when a
+        field doesn't exist in a query result or when it exists but is of
+        a type that cannot be safely cast to the target type. If this is a
+        scalar, the missing value applies to all fields. If this is a mapping,
+        the keys are field names and the values are the scalars to use for
+        missing entries for the named field.
+
+    Additional keyword-arguments passed to this method will be passed
+    directly to the underlying ``find`` operation.
+
+    :Returns:
+      An instance of class:`pandas.DataFrame`.
+    """
+    arrow_table = find_arrow_all(collection, query, schema=schema, **kwargs)
+    pandas_table = arrow_table.to_pandas(split_blocks=True, self_destruct=True)
+    return pandas_table
+
+
+def aggregate_pandas_all(collection, pipeline, *, schema, na_value=None, **kwargs):
+    """Method that returns the results of an aggregation pipeline as a
+    :class:`pandas.DataFrame` instance.
+
+    :Parameters:
+      - `collection`: Instance of :class:`~pymongo.collection.Collection`.
+        against which to run the ``find`` operation.
+      - `pipeline`: A list of aggregation pipeline stages.
+      - `schema`: Instance of :class:`~pymongoarrow.schema.Schema`.
+      - `na_value`: Scalar or mapping containing the value to use when a
+        field doesn't exist in a query result or when it exists but is of
+        a type that cannot be safely cast to the target type. If this is a
+        scalar, the missing value applies to all fields. If this is a mapping,
+        the keys are field names and the values are the scalars to use for
+        missing entries for the named field.
+
+    Additional keyword-arguments passed to this method will be passed
+    directly to the underlying ``aggregate`` operation.
+
+    :Returns:
+      An instance of class:`pandas.DataFrame`.
+    """
+    arrow_table = aggregate_arrow_all(
+        collection, pipeline, schema=schema, **kwargs)
+    pandas_table = arrow_table.to_pandas(split_blocks=True, self_destruct=True)
+    return pandas_table

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -103,7 +103,7 @@ def aggregate_arrow_all(collection, pipeline, *, schema, **kwargs):
     return context.finish()
 
 
-def _arrow_to_pandas_efficient(arrow_table):
+def _arrow_to_pandas(arrow_table):
     """Helper function that converts an Arrow Table to a Pandas DataFrame
     while minimizing peak memory consumption during conversion. The memory
     buffers backing the given Arrow Table are also destroyed after conversion.
@@ -130,7 +130,7 @@ def find_pandas_all(collection, query, *, schema, **kwargs):
     :Returns:
       An instance of class:`pandas.DataFrame`.
     """
-    return _arrow_to_pandas_efficient(
+    return _arrow_to_pandas(
         find_arrow_all(collection, query, schema=schema, **kwargs))
 
 
@@ -150,5 +150,5 @@ def aggregate_pandas_all(collection, pipeline, *, schema, **kwargs):
     :Returns:
       An instance of class:`pandas.DataFrame`.
     """
-    return _arrow_to_pandas_efficient(aggregate_arrow_all(
+    return _arrow_to_pandas(aggregate_arrow_all(
         collection, pipeline, schema=schema, **kwargs))

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -1,0 +1,83 @@
+# Copyright 2021-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# from datetime import datetime, timedelta
+import unittest
+import unittest.mock as mock
+
+from pyarrow import int32, int64
+from pymongo import WriteConcern, DESCENDING
+from pymongoarrow.api import aggregate_pandas_all, find_pandas_all, Schema
+import pandas as pd
+
+from test import client_context
+from test.utils import AllowListEventListener
+
+
+class TestExplicitPandasApi(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not client_context.connected:
+            raise unittest.SkipTest("cannot connect to MongoDB")
+        cls.cmd_listener = AllowListEventListener('find', 'aggregate')
+        cls.getmore_listener = AllowListEventListener('getMore')
+        cls.client = client_context.get_client(
+            event_listeners=[cls.getmore_listener, cls.cmd_listener])
+        cls.schema = Schema({'_id': int32(), 'data': int64()})
+        cls.coll = cls.client.pymongoarrow_test.get_collection(
+            'test', write_concern=WriteConcern(w='majority'))
+
+    def setUp(self):
+        self.coll.drop()
+        self.coll.insert_many([{'_id': 1, 'data': 10},
+                               {'_id': 2, 'data': 20},
+                               {'_id': 3, 'data': 30},
+                               {'_id': 4}])
+        self.cmd_listener.reset()
+        self.getmore_listener.reset()
+
+    def test_find_simple(self):
+        expected = pd.DataFrame(
+            data={'_id': [1, 2, 3, 4], 'data': [10, 20, 30, None]}).astype(
+            {'_id': 'int32'})
+
+        table = find_pandas_all(self.coll, {}, schema=self.schema)
+        self.assertTrue(table.equals(expected))
+
+        expected = pd.DataFrame(
+            data={'_id': [4, 3], 'data': [None, 30]}).astype(
+            {'_id': 'int32'})
+        table = find_pandas_all(self.coll, {'_id': {'$gt': 2}},
+                                schema=self.schema,
+                                sort=[('_id', DESCENDING)])
+        self.assertTrue(table.equals(expected))
+
+        find_cmd = self.cmd_listener.results['started'][-1]
+        self.assertEqual(find_cmd.command_name, 'find')
+        self.assertEqual(find_cmd.command['projection'],
+                         {'_id': True, 'data': True})
+
+    def test_aggregate_simple(self):
+        expected = pd.DataFrame(
+            data={'_id': [1, 2, 3, 4], 'data': [20, 40, 60, None]}).astype(
+            {'_id': 'int32'})
+        table = aggregate_pandas_all(
+            self.coll, [{'$project': {
+                '_id': True, 'data': {'$multiply': [2, '$data']}}}],
+            schema=self.schema)
+        self.assertTrue(table.equals(expected))
+
+        agg_cmd = self.cmd_listener.results['started'][-1]
+        self.assertEqual(agg_cmd.command_name, 'aggregate')
+        self.assertEqual(agg_cmd.command['pipeline'][1]['$project'],
+                         {'_id': True, 'data': True})


### PR DESCRIPTION
Though the design calls for it, I think we should drop the `na_value` field because pandas has great utilities for handling missing values - https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.fillna.html
If we did add `na_value` support it would basically be a pass-through which doesn't make too much sense to me... It might be better handled by really good docs. 