### PR TITLE
Modify setup.py such that it can detect libbson installed in standard locations

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -41,15 +41,17 @@ def query_pkgconfig(cmd):
 
 
 def append_libbson_flags(module):
-    pc_path = 'libbson-1.0.pc'
     install_dir = os.environ.get('LIBBSON_INSTALL_DIR')
     if install_dir:
         libdirs = glob.glob(os.path.join(install_dir, "lib*"))
         if len(libdirs) != 1:
-            warnings.warn("Unable to locate {}".format(pc_path))
+            warnings.warn("Unable to locate {}".format('libbson-1.0.pc'))
         else:
             libdir = libdirs[0]
-            pc_path = os.path.join(install_dir, libdir, 'pkgconfig', pc_path)
+            pc_path = os.path.join(
+                install_dir, libdir, 'pkgconfig', 'libbson-1.0.pc')
+    else:
+        pc_path = 'libbson-1.0'
 
     cflags = query_pkgconfig("pkg-config --cflags {}".format(pc_path))
     if cflags:


### PR DESCRIPTION
Modify `setup.py` to pick up `libbson` even when `LIBBSON_INSTALL_DIR` is unset but when `libbson` is discoverable via `pkg-config`.