### PR TITLE
PYTHON-2497 Add benchmark adapted from bson-numpy and increase perf by 50%

### DIFF
--- a/bindings/python/benchmark.py
+++ b/bindings/python/benchmark.py
@@ -141,19 +141,6 @@ def to_arrow(use_large):
     find_arrow_all(c, {}, schema=schema)
 
 
-@bench('decoded-cmd-reply')
-def bson_func(use_large):
-    for _ in BSON(raw_bsons[use_large]).decode()['cursor']['firstBatch']:
-        pass
-
-
-@bench('raw-cmd-reply')
-def raw_bson_func(use_large):
-    options = CodecOptions(document_class=RawBSONDocument)
-    for _ in BSON(raw_bsons[use_large]).decode(options)['cursor']['firstBatch']:
-        pass
-
-
 parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
                                  epilog="""
 Available benchmark functions:

--- a/bindings/python/benchmark.py
+++ b/bindings/python/benchmark.py
@@ -112,6 +112,8 @@ def conventional_ndarray(use_large):
         np.array([(doc['x'], doc['y']) for doc in cursor], dtype=dtype)
 
 
+# Note: this is called "to-numpy" and not "to-ndarray" because find_numpy_all
+# does not produce an ndarray.
 @bench('pymongoarrow-to-numpy')
 def to_numpy(use_large):
     c = db[collection_names[use_large]]

--- a/bindings/python/benchmark.py
+++ b/bindings/python/benchmark.py
@@ -1,0 +1,215 @@
+import argparse
+import collections
+import math
+import string
+import sys
+import timeit
+from functools import partial
+
+import numpy as np
+import pandas as pd
+import pymongo
+
+from bson import BSON, CodecOptions, Int64, ObjectId
+from bson.raw_bson import RawBSONDocument
+
+import pyarrow
+from pymongoarrow.api import find_arrow_all, find_numpy_all, Schema, find_pandas_all
+
+assert pymongo.has_c()
+
+# Use large document in tests? If SMALL, no, if LARGE, then yes.
+SMALL = False
+LARGE = True
+db = None
+raw_bson = None
+large_doc_keys = None
+collection_names = {LARGE: "large", SMALL: "small"}
+dtypes = {}
+schemas = {}
+raw_bsons = {}
+
+
+def _setup():
+    global db
+    global raw_bson
+    global large_doc_keys
+
+    db = pymongo.MongoClient().pymongoarrow_test
+    small = db[collection_names[SMALL]]
+    small.drop()
+
+    print("%d small docs, %d bytes each with 3 keys" % (
+        N_SMALL_DOCS,
+        len(BSON.encode({'_id': ObjectId(), 'x': 1, 'y': math.pi}))))
+
+    small.insert_many([
+        collections.OrderedDict([('x', 1), ('y', math.pi)])
+        for _ in range(N_SMALL_DOCS)])
+
+    dtypes[SMALL] = np.dtype([('x', np.int64), ('y', np.float64)])
+    schemas[SMALL] = Schema({'x': pyarrow.int64(), 'y': pyarrow.float64()})
+
+    large = db[collection_names[LARGE]]
+    large.drop()
+    # 2600 keys: 'a', 'aa', 'aaa', .., 'zz..z'
+    large_doc_keys = [c * i for c in string.ascii_lowercase
+                      for i in range(1, 101)]
+    large_doc = collections.OrderedDict([(k, math.pi) for k in large_doc_keys])
+    print("%d large docs, %dk each with %d keys" % (
+        N_LARGE_DOCS, len(BSON.encode(large_doc)) // 1024, len(large_doc_keys)))
+
+    large.insert_many([large_doc.copy() for _ in range(N_LARGE_DOCS)])
+
+    dtypes[LARGE] = np.dtype([(k, np.float64) for k in large_doc_keys])
+    schemas[LARGE] = Schema({k: pyarrow.float64() for k in large_doc_keys})
+
+    # Ignore for now that the first batch defaults to 101 documents.
+    raw_bson_docs_small = [{'x': 1, 'y': math.pi} for _ in range(N_SMALL_DOCS)]
+    raw_bson_small = BSON.encode({'ok': 1,
+                                  'cursor': {
+                                      'id': Int64(1234),
+                                      'ns': 'db.collection',
+                                      'firstBatch': raw_bson_docs_small}})
+
+    raw_bson_docs_large = [large_doc.copy() for _ in range(N_LARGE_DOCS)]
+    raw_bson_large = BSON.encode({'ok': 1,
+                                  'cursor': {
+                                      'id': Int64(1234),
+                                      'ns': 'db.collection',
+                                      'firstBatch': raw_bson_docs_large}})
+
+    raw_bsons[SMALL] = raw_bson_small
+    raw_bsons[LARGE] = raw_bson_large
+
+
+def _teardown():
+    db.collection.drop()
+
+
+bench_fns = collections.OrderedDict()
+
+
+def bench(name):
+    def assign_name(fn):
+        assert fn not in bench_fns.values()
+        bench_fns[name] = fn
+        return fn
+
+    return assign_name
+
+
+@bench('conventional-to-ndarray')
+def conventional_ndarray(use_large):
+    collection = db[collection_names[use_large]]
+    cursor = collection.find()
+    dtype = dtypes[use_large]
+
+    if use_large:
+        np.array([tuple(doc[k] for k in large_doc_keys) for doc in cursor],
+                 dtype=dtype)
+    else:
+        np.array([(doc['x'], doc['y']) for doc in cursor], dtype=dtype)
+
+
+@bench('pymongoarrow-to-numpy')
+def to_numpy(use_large):
+    c = db[collection_names[use_large]]
+    schema = schemas[use_large]
+    find_numpy_all(c, {}, schema=schema)
+
+
+@bench('conventional-to-pandas')
+def conventional_pandas(use_large):
+    collection = db[collection_names[use_large]]
+    dtype = dtypes[use_large]
+    cursor = collection.find(projection={'_id': 0})
+    data_frame = pd.DataFrame(list(cursor))
+
+
+@bench('pymongoarrow-to-pandas')
+def to_pandas(use_large):
+    c = db[collection_names[use_large]]
+    schema = schemas[use_large]
+    find_pandas_all(c, {}, schema=schema)
+
+
+@bench('pymongoarrow-to-arrow')
+def to_arrow(use_large):
+    c = db[collection_names[use_large]]
+    schema = schemas[use_large]
+    find_arrow_all(c, {}, schema=schema)
+
+
+@bench('decoded-cmd-reply')
+def bson_func(use_large):
+    for _ in BSON(raw_bsons[use_large]).decode()['cursor']['firstBatch']:
+        pass
+
+
+@bench('raw-cmd-reply')
+def raw_bson_func(use_large):
+    options = CodecOptions(document_class=RawBSONDocument)
+    for _ in BSON(raw_bsons[use_large]).decode(options)['cursor']['firstBatch']:
+        pass
+
+
+parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
+                                 epilog="""
+Available benchmark functions:
+   %s
+""" % ("\n   ".join(bench_fns.keys()),))
+parser.add_argument('--large', action='store_true',
+                    help='only test with large documents')
+parser.add_argument('--small', action='store_true',
+                    help='only test with small documents')
+parser.add_argument('--test', action='store_true',
+                    help='quick test of benchmark.py')
+parser.add_argument('funcs', nargs='*', default=bench_fns.keys())
+options = parser.parse_args()
+
+if options.test:
+    N_LARGE_DOCS = 2
+    N_SMALL_DOCS = 2
+    N_TRIALS = 1
+else:
+    N_LARGE_DOCS = 1000
+    N_SMALL_DOCS = 100000
+    N_TRIALS = 5
+
+# Run tests with both small and large documents.
+sizes = [SMALL, LARGE]
+if options.large and not options.small:
+    sizes.remove(SMALL)
+if options.small and not options.large:
+    sizes.remove(LARGE)
+
+for name in options.funcs:
+    if name not in bench_fns:
+        sys.stderr.write("Unknown function \"%s\"\n" % name)
+        sys.stderr.write("Available functions:\n%s\n" % ("\n".join(bench_fns)))
+        sys.exit(1)
+
+_setup()
+
+print()
+print("%25s: %7s %7s" % ("BENCH", "SMALL", "LARGE"))
+
+for name, fn in bench_fns.items():
+    if name in options.funcs:
+        sys.stdout.write("%25s: " % name)
+        sys.stdout.flush()
+
+        # Test with small and large documents.
+        for size in (SMALL, LARGE):
+            if size not in sizes:
+                sys.stdout.write("%7s" % "-")
+            else:
+                timer = timeit.Timer(partial(fn, size))
+                duration = min(timer.repeat(3, N_TRIALS)) / float(N_TRIALS)
+                sys.stdout.write("%7.2f " % duration)
+            sys.stdout.flush()
+
+        sys.stdout.write("\n")
+
+_teardown()

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -172,7 +172,7 @@ def _arrow_to_numpy(arrow_table, schema):
     return container
 
 
-def find_numpy_all(collection, query, *, schema, writable=False, **kwargs):
+def find_numpy_all(collection, query, *, schema, **kwargs):
     """Method that returns the results of a find query as a
     :class:`dict` instance whose keys are field names and values are
     :class:`~numpy.ndarray` instances bearing the appropriate dtype.

--- a/bindings/python/pymongoarrow/bson.pyi
+++ b/bindings/python/pymongoarrow/bson.pyi
@@ -31,8 +31,12 @@ def process_bson_stream(bson_stream, context):
     cdef bson_type_t value_t
     cdef Py_ssize_t count = 0
 
+    # Localize types for better performance.
+    t_int32 = _BsonArrowTypes.int32
+    t_int64 = _BsonArrowTypes.int64
+    t_double = _BsonArrowTypes.double
+    t_datetime = _BsonArrowTypes.datetime
     builder_map = context.builder_map
-    type_map = context.type_map
 
     # initialize count to current length of builders
     for _, builder in builder_map.items():
@@ -50,14 +54,14 @@ def process_bson_stream(bson_stream, context):
                 key = bson_iter_key(&doc_iter)
                 builder = builder_map.get(key)
                 if builder is not None:
-                    ftype = type_map[key]
+                    ftype = builder.type_marker
                     value_t = bson_iter_type(&doc_iter)
-                    if ftype == _BsonArrowTypes.int32:
+                    if ftype == t_int32:
                         if value_t == BSON_TYPE_INT32:
                             builder.append(bson_iter_int32(&doc_iter))
                         else:
                             builder.append_null()
-                    elif ftype == _BsonArrowTypes.int64:
+                    elif ftype == t_int64:
                         if (value_t == BSON_TYPE_INT64 or
                                 value_t == BSON_TYPE_BOOL or
                                 value_t == BSON_TYPE_DOUBLE or
@@ -65,7 +69,7 @@ def process_bson_stream(bson_stream, context):
                             builder.append(bson_iter_as_int64(&doc_iter))
                         else:
                             builder.append_null()
-                    elif ftype == _BsonArrowTypes.double:
+                    elif ftype == t_double:
                         if (value_t == BSON_TYPE_DOUBLE or
                                 value_t == BSON_TYPE_BOOL or
                                 value_t == BSON_TYPE_INT32 or
@@ -73,7 +77,7 @@ def process_bson_stream(bson_stream, context):
                             builder.append(bson_iter_as_double(&doc_iter))
                         else:
                             builder.append_null()
-                    elif ftype == _BsonArrowTypes.datetime:
+                    elif ftype == t_datetime:
                         if value_t == BSON_TYPE_DATE_TIME:
                             builder.append(bson_iter_date_time(&doc_iter))
                         else:

--- a/bindings/python/pymongoarrow/bson.pyi
+++ b/bindings/python/pymongoarrow/bson.pyi
@@ -48,8 +48,8 @@ def process_bson_stream(bson_stream, context):
                 raise InvalidBSON("Could not read BSON document")
             while bson_iter_next(&doc_iter):
                 key = bson_iter_key(&doc_iter)
-                if key in builder_map:
-                    builder = builder_map[key]
+                builder = builder_map.get(key)
+                if builder is not None:
                     ftype = type_map[key]
                     value_t = bson_iter_type(&doc_iter)
                     if ftype == _BsonArrowTypes.int32:

--- a/bindings/python/pymongoarrow/builders.pyi
+++ b/bindings/python/pymongoarrow/builders.pyi
@@ -20,6 +20,7 @@ cdef class _ArrayBuilderBase:
 
 
 cdef class Int32Builder(_ArrayBuilderBase):
+    type_marker = _BsonArrowTypes.int32
     cdef:
         shared_ptr[CInt32Builder] builder
 
@@ -52,6 +53,7 @@ cdef class Int32Builder(_ArrayBuilderBase):
 
 
 cdef class Int64Builder(_ArrayBuilderBase):
+    type_marker = _BsonArrowTypes.int64
     cdef:
         shared_ptr[CInt64Builder] builder
 
@@ -84,6 +86,7 @@ cdef class Int64Builder(_ArrayBuilderBase):
 
 
 cdef class DoubleBuilder(_ArrayBuilderBase):
+    type_marker = _BsonArrowTypes.double
     cdef:
         shared_ptr[CDoubleBuilder] builder
 
@@ -116,6 +119,7 @@ cdef class DoubleBuilder(_ArrayBuilderBase):
 
 
 cdef class DatetimeBuilder(_ArrayBuilderBase):
+    type_marker = _BsonArrowTypes.datetime
     cdef:
         shared_ptr[CTimestampBuilder] builder
         TimestampType dtype

--- a/bindings/python/pymongoarrow/builders.pyi
+++ b/bindings/python/pymongoarrow/builders.pyi
@@ -27,13 +27,13 @@ cdef class Int32Builder(_ArrayBuilderBase):
         cdef CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
         self.builder.reset(new CInt32Builder(pool))
 
-    def append_null(self):
+    cpdef append_null(self):
         self.builder.get().AppendNull()
 
     def __len__(self):
         return self.builder.get().length()
 
-    def append(self, value):
+    cpdef append(self, value):
         if value is None or value is np.nan:
             self.builder.get().AppendNull()
         elif isinstance(value, int):
@@ -41,7 +41,7 @@ cdef class Int32Builder(_ArrayBuilderBase):
         else:
             raise TypeError('Int32Builder only accepts integer objects')
 
-    def finish(self):
+    cpdef finish(self):
         cdef shared_ptr[CArray] out
         with nogil:
             self.builder.get().Finish(&out)
@@ -59,13 +59,13 @@ cdef class Int64Builder(_ArrayBuilderBase):
         cdef CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
         self.builder.reset(new CInt64Builder(pool))
 
-    def append_null(self):
+    cpdef append_null(self):
         self.builder.get().AppendNull()
 
     def __len__(self):
         return self.builder.get().length()
 
-    def append(self, value):
+    cpdef append(self, value):
         if value is None or value is np.nan:
             self.builder.get().AppendNull()
         elif isinstance(value, int):
@@ -73,7 +73,7 @@ cdef class Int64Builder(_ArrayBuilderBase):
         else:
             raise TypeError('Int64Builder only accepts integer objects')
 
-    def finish(self):
+    cpdef finish(self):
         cdef shared_ptr[CArray] out
         with nogil:
             self.builder.get().Finish(&out)
@@ -91,13 +91,13 @@ cdef class DoubleBuilder(_ArrayBuilderBase):
         cdef CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
         self.builder.reset(new CDoubleBuilder(pool))
 
-    def append_null(self):
+    cpdef append_null(self):
         self.builder.get().AppendNull()
 
     def __len__(self):
         return self.builder.get().length()
 
-    def append(self, value):
+    cpdef append(self, value):
         if value is None or value is np.nan:
             self.builder.get().AppendNull()
         elif isinstance(value, (int, float)):
@@ -105,7 +105,7 @@ cdef class DoubleBuilder(_ArrayBuilderBase):
         else:
             raise TypeError('DoubleBuilder only accepts floats and ints')
 
-    def finish(self):
+    cpdef finish(self):
         cdef shared_ptr[CArray] out
         with nogil:
             self.builder.get().Finish(&out)
@@ -131,13 +131,13 @@ cdef class DatetimeBuilder(_ArrayBuilderBase):
         self.builder.reset(new CTimestampBuilder(
             pyarrow_unwrap_data_type(self.dtype), pool))
 
-    def append_null(self):
+    cpdef append_null(self):
         self.builder.get().AppendNull()
 
     def __len__(self):
         return self.builder.get().length()
 
-    def append(self, value):
+    cpdef append(self, value):
         if value is None or value is np.nan:
             self.builder.get().AppendNull()
         elif isinstance(value, int):
@@ -145,7 +145,7 @@ cdef class DatetimeBuilder(_ArrayBuilderBase):
         else:
             raise TypeError('TimestampBuilder only accepts 64-bit integers')
 
-    def finish(self):
+    cpdef finish(self):
         cdef shared_ptr[CArray] out
         with nogil:
             self.builder.get().Finish(&out)

--- a/bindings/python/pymongoarrow/context.py
+++ b/bindings/python/pymongoarrow/context.py
@@ -28,19 +28,16 @@ _TYPE_TO_BUILDER_CLS = {
 
 class PyMongoArrowContext:
     """A context for converting BSON-formatted data to an Arrow Table."""
-    def __init__(self, schema, builder_map, type_map):
+    def __init__(self, schema, builder_map):
         """Initialize the context.
 
         :Parameters:
           - `schema`: Instance of :class:`~pymongoarrow.schema.Schema`.
           - `builder_map`: Mapping of utf-8-encoded field names to
             :class:`~pymongoarrow.builders._BuilderBase` instances.
-          - `type_map`: Mapping of utf-8-encoded field names to
-            :class:`~pymongoarrow.types._BsonArrowTypes` instances.
         """
         self.schema = schema
         self.builder_map = builder_map
-        self.type_map = type_map
 
     @classmethod
     def from_schema(cls, schema, codec_options=DEFAULT_CODEC_OPTIONS):
@@ -53,7 +50,6 @@ class PyMongoArrowContext:
             :class:`~bson.codec_options.CodecOptions`.
         """
         builder_map = {}
-        type_map = {}
         str_type_map = _get_internal_typemap(schema.typemap)
         for fname, ftype in str_type_map.items():
             builder_cls = _TYPE_TO_BUILDER_CLS[ftype]
@@ -67,8 +63,7 @@ class PyMongoArrowContext:
                 builder_map[encoded_fname] = builder_cls(dtype=arrow_type)
             else:
                 builder_map[encoded_fname] = builder_cls()
-            type_map[encoded_fname] = ftype
-        return cls(schema, builder_map, type_map)
+        return cls(schema, builder_map)
 
     def finish(self):
         arrays = []

--- a/bindings/python/pymongoarrow/lib.pyx
+++ b/bindings/python/pymongoarrow/lib.pyx
@@ -35,6 +35,7 @@ from libcpp.map cimport map
 from libcpp.string cimport string
 from pyarrow.lib cimport *
 from pymongoarrow.libbson cimport *
+from pymongoarrow.types import _BsonArrowTypes
 
 
 # libbson version


### PR DESCRIPTION
Adapted from https://github.com/mongodb/bson-numpy/blob/c0bacea/benchmark.py

Here's the benchmark output on my machine before the optimizations:
```
100000 small docs, 40 bytes each with 3 keys
1000 large docs, 153k each with 2600 keys
                    BENCH:   SMALL   LARGE
  conventional-to-ndarray:    0.27    1.13
    pymongoarrow-to-numpy:    0.14    2.36
   conventional-to-pandas:    0.35    1.69
   pymongoarrow-to-pandas:    0.14    2.41
    pymongoarrow-to-arrow:    0.14    2.35
```

And here is the improved output:
```
100000 small docs, 40 bytes each with 3 keys
1000 large docs, 153k each with 2600 keys
                    BENCH:   SMALL   LARGE
  conventional-to-ndarray:    0.27    1.17
    pymongoarrow-to-numpy:    0.10    1.25
   conventional-to-pandas:    0.36    1.82
   pymongoarrow-to-pandas:    0.10    1.32
    pymongoarrow-to-arrow:    0.10    1.26
```

This is about a 50% improvement.