### PR TITLE
Add required metadata field URL to setup.py

### DIFF
--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -140,6 +140,7 @@ setup(
     author_email="mongodb-user@googlegroups.com",
     maintainer="MongoDB, Inc.",
     maintainer_email="mongodb-user@googlegroups.com",
+    url="https://github.com/mongodb-labs/mongo-arrow/tree/main/bindings/python",
     keywords=["mongo", "mongodb", "pymongo", "arrow", "bson",
               "numpy", "pandas"],
     test_suite="test"


### PR DESCRIPTION
I noticed this when `python setup.py check` ran as a part of `python setup.py sdist` and produced the following output:
```
running check
warning: check: missing required meta-data: url
```
I don't think it affects any functionality but obviously we need to fix it.