### PR TITLE
PYTHON-3047 Clean up handling of pyarrow library

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+defaults:  
+  run:  
+    working-directory: ./bindings/python
+
 jobs:
   build:
     # supercharge/mongodb-github-action requires containers so we don't test other platforms
@@ -27,17 +31,17 @@ jobs:
       - name: Install libbson
         run: |
           LIBBSON_INSTALL_DIR=$(pwd)/libbson ./build-libbson.sh
-        working-directory: ./bindings/python
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip
-        working-directory: ./bindings/python
       - name: Install pymongoarrow
         run: |
           # Install the library
           LIBBSON_INSTALL_DIR=$(pwd)/libbson python -m pip install -vvv -e ".[test]"
-        working-directory: ./bindings/python
       - name: Run tests
         run: |
           LD_LIBRARY_PATH=$(pwd)/libbson/lib python -m unittest discover test -v
-        working-directory: ./bindings/python
+      - name: Check the manifest
+        run: |
+          pip install check-manifest
+          check-manifest -v

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -30,15 +30,12 @@ jobs:
         working-directory: ./bindings/python
       - name: Install Python dependencies
         run: |
-          python -m pip install -U pip wheel
-          python -m pip install -r requirements/test.txt
+          python -m pip install -U pip
         working-directory: ./bindings/python
       - name: Install pymongoarrow
         run: |
-          # Use pip install to pull in install_requires dependencies
-          LIBBSON_INSTALL_DIR=$(pwd)/libbson python -m pip install -e .
-          # Re-compile to see compiler/linker output in the logs
-          LIBBSON_INSTALL_DIR=$(pwd)/libbson python setup.py build_ext --inplace --force
+          # Install the library
+          LIBBSON_INSTALL_DIR=$(pwd)/libbson python -m pip install -vvv -e ".[test]"
         working-directory: ./bindings/python
       - name: Run tests
         run: |

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           python -m pip install -U pip wheel
           python -m pip install -r requirements/test.txt
-          python -c 'import pyarrow as pa; pa.create_library_symlinks()'
         working-directory: ./bindings/python
       - name: Install pymongoarrow
         run: |

--- a/bindings/python/.gitignore
+++ b/bindings/python/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.dylib
 
 # Distribution / packaging
 .Python

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -15,6 +15,7 @@ recursive-exclude docs *
 global-exclude *.cpp
 global-exclude *.dylib
 global-exclude *.so.*
+global-exclude *.so
 global-exclude *.pyc
 global-exclude .git*
 global-exclude .DS_Store

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -2,10 +2,14 @@ include README.rst
 include LICENSE
 include build-libbson.sh
 include release.sh
+include addtags.py
+include benchmark.py
+include THIRD-PARTY-NOTICES
 
 graft pymongoarrow
 
-prune test
+recursive-exclude test *
+recursive-exclude docs *
 
 global-exclude *.cpp
 global-exclude *.dylib

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,11 +1,12 @@
 include README.rst
 include LICENSE
 include build-libbson.sh
-include release.sh
-include addtags.py
-include benchmark.py
-include THIRD-PARTY-NOTICES
 include pyproject.toml
+
+exclude THIRD-PARTY-NOTICES
+exclude release.sh
+exclude addtags.py
+exclude benchmark.py
 
 graft pymongoarrow
 

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -5,6 +5,7 @@ include release.sh
 include addtags.py
 include benchmark.py
 include THIRD-PARTY-NOTICES
+include pyproject.toml
 
 graft pymongoarrow
 
@@ -13,7 +14,7 @@ recursive-exclude docs *
 
 global-exclude *.cpp
 global-exclude *.dylib
-global-exclude *.so
+global-exclude *.so.*
 global-exclude *.pyc
 global-exclude .git*
 global-exclude .DS_Store

--- a/bindings/python/docs/source/developer/installation.rst
+++ b/bindings/python/docs/source/developer/installation.rst
@@ -41,23 +41,22 @@ On macOS, users can install the latest ``libbson`` via Homebrew::
 
   $ brew install mongo-c-driver
 
+Alternatively, you can use the provided `build-libbson.sh` script to build it::
+
+  $ LIBBSON_INSTALL_DIR=$(pwd)/libbson build-libbson.sh
+
 
 Build
 -----
 
-In the previously created virtualenv, we first install all build and test dependencies
-of PyMongoArrow::
+In the previously created virtualenv, install PyMongoArrow and its test dependencies in editable mode::
 
-  (pymongoarrow) $ pip install -r requirements/test.txt
+  (pymongoarrow) $ pip install -v -e ".[test]"
 
-We also need the pyarrow library symlinks, which can be created as follows::
- 
-  (pymongoarrow) $ python -c 'import pyarrow as pa; pa.create_library_symlinks()'
+If you built libbson using the `build-libbson` script then use the same `LIBBSON_INSTALL_DIR` as above:
 
-We can now install ``pymongoarrow`` in **development mode** as follows::
+  (pymongoarrow) $ LIBBSON_INSTALL_DIR=$(pwd)/libbson pip install -v -e ".[test]"
 
-  (pymongoarrow) $ python setup.py build_ext --inplace
-  (pymongoarrow) $ python setup.py develop
 
 Test
 ----

--- a/bindings/python/docs/source/developer/installation.rst
+++ b/bindings/python/docs/source/developer/installation.rst
@@ -43,7 +43,7 @@ On macOS, users can install the latest ``libbson`` via Homebrew::
 
 Alternatively, you can use the provided `build-libbson.sh` script to build it::
 
-  $ LIBBSON_INSTALL_DIR=$(pwd)/libbson build-libbson.sh
+  $ LIBBSON_INSTALL_DIR=$(pwd)/libbson ./build-libbson.sh
 
 
 Build

--- a/bindings/python/pymongoarrow/__init__.py
+++ b/bindings/python/pymongoarrow/__init__.py
@@ -15,13 +15,10 @@ import os
 # We must import pyarrow before attempting to load the Cython module.
 import pyarrow
 
-try:
-    from pymongoarrow.lib import libbson_version
-except ImportError:
-    # Import is not available during package build
-    pass
 from pymongoarrow.version import __version__, _MIN_LIBBSON_VERSION
-
+# this line must come second so setuptools can parse the __version__
+# above without having a built application
+from pymongoarrow.lib import libbson_version
 
 try:
     from pkg_resources import parse_version as _parse_version

--- a/bindings/python/pymongoarrow/__init__.py
+++ b/bindings/python/pymongoarrow/__init__.py
@@ -15,7 +15,11 @@ import os
 # We must import pyarrow before attempting to load the Cython module.
 import pyarrow
 
-from pymongoarrow.lib import libbson_version
+try:
+    from pymongoarrow.lib import libbson_version
+except ImportError:
+    # Import is not available during package build
+    pass
 from pymongoarrow.version import __version__, _MIN_LIBBSON_VERSION
 
 

--- a/bindings/python/pymongoarrow/__init__.py
+++ b/bindings/python/pymongoarrow/__init__.py
@@ -16,8 +16,8 @@ import os
 import pyarrow
 
 from pymongoarrow.version import __version__, _MIN_LIBBSON_VERSION
-# this line must come second so setuptools can parse the __version__
-# above without having a built application
+# This line must come second so setuptools can parse the __version__
+# above without having a built application.
 from pymongoarrow.lib import libbson_version
 
 try:

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -3,6 +3,6 @@ requires = [
     "setuptools>=47.9",
     "wheel",
     "cython>=0.29",
-    # Must be kept in sync with the `setup_requirements` in `setup.py`
+    # Must be kept in sync with the `install_requires` in `setup.cfg`
     "pyarrow>=6.0.0,<6.1.0",
 ]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools>=47.9",
+    "wheel",
+    "cython>=0.29",
+    # Must be kept in sync with the `setup_requirements` in `setup.py`
+    "pyarrow>=6.0.0,<6.1.0",
+]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -6,3 +6,6 @@ requires = [
     # Must be kept in sync with the `install_requires` in `setup.cfg`
     "pyarrow>=6.0.0,<6.1.0",
 ]
+
+[tool.check-manifest]
+ignore = ["pymongoarrow/*.so*.*", "pymongoarrow/*.dylib"]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,11 +1,15 @@
 [build-system]
 requires = [
     "setuptools>=47.9",
-    "wheel",
+    "wheel>=0.37",
     "cython>=0.29",
     # Must be kept in sync with the `install_requires` in `setup.cfg`
     "pyarrow>=6.0.0,<6.1.0",
 ]
 
 [tool.check-manifest]
-ignore = ["pymongoarrow/*.so*.*", "pymongoarrow/*.so*.*", "pymongoarrow/*.dylib"]
+ignore = [
+    "pymongoarrow/*.so*.*", 
+    "pymongoarrow/*.so*", 
+    "pymongoarrow/*.dylib"
+]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -8,4 +8,4 @@ requires = [
 ]
 
 [tool.check-manifest]
-ignore = ["pymongoarrow/*.so*.*", "pymongoarrow/*.dylib"]
+ignore = ["pymongoarrow/*.so*.*", "pymongoarrow/*.so*.*", "pymongoarrow/*.dylib"]

--- a/bindings/python/release.sh
+++ b/bindings/python/release.sh
@@ -38,14 +38,10 @@ $PYTHON --version
 cp $LIBBSON_INSTALL_DIR/lib*/$LIBBSON_SO "$(pwd)/pymongoarrow/"
 
 # Install build dependencies
-$PYTHON -m pip install -U pip wheel
-$PYTHON -m pip install -r requirements/build.txt
-
-# https://arrow.apache.org/docs/python/extending.html#building-extensions-against-pypi-wheels
-$PYTHON -c "import pyarrow; pyarrow.create_library_symlinks()"
+$PYTHON -m pip install -U pip build
 
 # Build wheels in $(pwd)/dist/*.whl
-LIBBSON_INSTALL_DIR="$LIBBSON_INSTALL_DIR" $PYTHON setup.py bdist_wheel
+LIBBSON_INSTALL_DIR="$LIBBSON_INSTALL_DIR" $PYTHON -m build --wheel .
 
 # Run auditwheel repair to set platform tags on Linux
 if [ "Linux" = "$(uname -s)" ]

--- a/bindings/python/requirements/build.txt
+++ b/bindings/python/requirements/build.txt
@@ -1,3 +1,0 @@
-setuptools>=47
-cython>=0.29
-pyarrow>=6,<6.1

--- a/bindings/python/requirements/test.txt
+++ b/bindings/python/requirements/test.txt
@@ -1,3 +1,0 @@
--r build.txt
-pandas
-pytz

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -33,6 +33,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.6
 install_requires =
+    # keep versions in sync with pyproject.toml "requires"
     pyarrow >=6,<6.1
     pymongo >=3.11,<5
 

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -41,5 +41,10 @@ install_requires =
 [options.package_data]
 pymongoarrow = *.pxd, *.pyx, *.pyi, *.so.*, *.dylib
 
+[options.packages.find]
+exclude =
+    test
+    docs
+
 [options.extras_require]
 test = pandas;pytz

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -42,6 +42,3 @@ pymongoarrow = *.pxd, *.pyx, *.pyi, *.so.*, *.dylib
 
 [options.extras_require]
 test = pandas;pytz
-
-[bdist_wheel]
-universal=1

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Database
 

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -1,0 +1,46 @@
+
+[metadata]
+name = pymongoarrow
+version = attr: pymongoarrow.version.__version__
+description = "Tools for using NumPy, Pandas and PyArrow with MongoDB"
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+license = Apache License, Version 2.0
+author = Prashant Mital
+maintainer = MongoDB, Inc.
+url = https://github.com/mongodb-labs/mongo-arrow/tree/main/bindings/python
+platforms = Linux, Mac OS X, Windows
+keywords = mongo, mongodb, pymongo, arrow, bson, numpy, pandas
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: Apache Software License
+    Operating System :: MacOS :: MacOS X
+    Operating System :: POSIX
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Database
+
+[options]
+zip_safe = False
+include_package_data = True
+packages = find:
+python_requires = >=3.6
+install_requires =
+    pyarrow >=6,<6.1
+    pymongo >=3.11,<5
+
+[options.package_data]
+pymongoarrow = *.pxd, *.pyx, *.pyi, *.so.*, *.dylib
+
+[options.extras_require]
+test = pandas;pytz
+
+[bdist_wheel]
+universal=1

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -9,7 +9,7 @@ license = Apache License, Version 2.0
 author = Prashant Mital
 maintainer = MongoDB, Inc.
 url = https://github.com/mongodb-labs/mongo-arrow/tree/main/bindings/python
-platforms = Linux, Mac OS X, Windows
+platforms = Linux, Mac OS X
 keywords = mongo, mongodb, pymongo, arrow, bson, numpy, pandas
 classifiers =
     Development Status :: 3 - Alpha

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -24,6 +24,7 @@ def query_pkgconfig(cmd):
 
 
 def append_libbson_flags(module):
+    pc_path = 'libbson-1.0'
     install_dir = os.environ.get('LIBBSON_INSTALL_DIR')
     if install_dir:
         libdirs = glob.glob(os.path.join(install_dir, "lib*"))
@@ -33,8 +34,6 @@ def append_libbson_flags(module):
             libdir = libdirs[0]
             pc_path = os.path.join(
                 install_dir, libdir, 'pkgconfig', 'libbson-1.0.pc')
-    else:
-        pc_path = 'libbson-1.0'
 
     lnames = query_pkgconfig("pkg-config --libs-only-l {}".format(pc_path))
     if not lnames:
@@ -81,21 +80,17 @@ def append_arrow_flags(module):
     # then look for a library file with a version modifier, e.g. libarrow.600.dylib.
     arrow_lib = os.environ.get('MONGO_ARROW_LIBDIR', pa.get_library_dirs()[0])
     if platform == "darwin":
-        exts = [r'\.dylib', r'\..*\.dylib']
+        exts = ['.dylib', '.*.dylib']
     elif platform == 'linux':
-        exts = [r'\.so', r'\.so\..*']
+        exts = ['.so', '.so.*']
 
     # Find the appropriate library file and optionally copy it locally.
-    files = os.listdir(arrow_lib)
     for name in pa.get_libraries():
         for ext in exts:
-            path = None
-            pattern = re.compile(f'lib{name}{ext}$')
-            for fname in files:
-                if re.match(pattern, fname):
-                    path = os.path.join(arrow_lib, fname)
-            if not path:
+            files = glob.glob(os.path.join(arrow_lib, f'lib{name}{ext}'))
+            if not files:
                 continue
+            path = files[0]
     
             # You can use MONGO_NO_COPY_ARROW_LIB to avoid copying the arrow library
             # files to the build directory (for instance in a conda build).

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -83,7 +83,7 @@ def append_arrow_flags(module):
     if platform == "darwin":
         exts = ['.dylib$', r'.(\d+).dylib$']
     elif platform == 'linux':
-        exts = ['.so$', r'(.so.\d+)$']
+        exts = ['.so$', r'.(so.\d+)$']
 
     # Find the appropriate library file and optionally copy it locally.
     # If the library file has a version modifier, use the modifier in the library

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 
 import glob
 import os
+import re
 import subprocess
 from sys import platform
 import warnings
@@ -80,25 +81,33 @@ def append_arrow_flags(module):
     # then look for a library file with a version modifier, e.g. libarrow.600.dylib.
     arrow_lib = os.environ.get('MONGO_ARROW_LIBDIR', pa.get_library_dirs()[0])
     if platform == "darwin":
-        patterns = ['.dylib', '.[0-9][0-9][0-9].dylib']
+        exts = ['.dylib', r'.(\d+).dylib']
     elif platform == 'linux':
-        patterns = ['.so', '.so.[0-9][0-9][0-9]']
+        exts = ['.so', r'.so.(\d+)']
 
-    # Handle linking and optionally copy the library files
-    for name in ['libarrow', 'libarrow_python']:
-        for pattern in patterns:
-            paths = glob.glob(os.path.join(arrow_lib, name + pattern))
-            if not paths:
-                continue
-            path = paths[0]
-            # You can use MONGO_NO_COPY_ARROW_LIB to avoid copying the arrow library
-            # files to the build directory (for instance in a conda build).
-            if not os.environ.get("MONGO_NO_COPY_ARROW_LIB", False):
-                build_dir = os.path.join(HERE, 'pymongoarrow')
-                shutil.copy(path, build_dir)
-                path = os.path.join(build_dir, os.path.basename(path))
-            module.extra_link_args.append(path)
-            break
+    # Find the appropriate library file and optionally copy it locally.
+    # If the library file has a version modifier, use the modifier in the library
+    # name given to setuptools.
+    files = os.listdir(arrow_lib)
+    for name in pa.get_libraries():
+        matched = False
+        for ext in exts:
+            if matched: 
+                break
+            pattern = re.compile('lib' + name + ext)
+            for fname in files:
+                match = re.match(pattern, fname)
+                if not match:
+                    continue
+                module.libraries.append(name + '.' + match.groups()[0])
+                matched = True
+                # You can use MONGO_NO_COPY_ARROW_LIB to avoid copying the arrow library
+                # files to the build directory (for instance in a conda build).
+                if not os.environ.get("MONGO_NO_COPY_ARROW_LIB", False):
+                    build_dir = os.path.join(HERE, 'pymongoarrow')
+                    path = os.path.join(arrow_lib, fname)
+                    shutil.copy(path, build_dir)
+                break
 
     # Arrow's manylinux{2010, 2014} binaries are built with gcc < 4.8 which predates CXX11 ABI
     # - https://uwekorn.com/2019/09/15/how-we-build-apache-arrows-manylinux-wheels.html

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -100,6 +100,7 @@ def append_arrow_flags(module):
         if not os.environ.get("MONGO_NO_COPY_ARROW_LIB", False):
             build_dir = os.path.join(HERE, 'pymongoarrow')
             shutil.copy(path, build_dir)
+            path = os.path.join(build_dir, os.path.basename(path))
         module.extra_link_args.append(path)
 
     # Arrow's manylinux{2010, 2014} binaries are built with gcc < 4.8 which predates CXX11 ABI

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -83,7 +83,7 @@ def append_arrow_flags(module):
     if platform == "darwin":
         exts = ['.dylib$', r'.(\d+).dylib$']
     elif platform == 'linux':
-        exts = ['.so$', r'.so.(\d+)$']
+        exts = ['.so$', r'(.so.\d+)$']
 
     # Find the appropriate library file and optionally copy it locally.
     # If the library file has a version modifier, use the modifier in the library

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -81,9 +81,9 @@ def append_arrow_flags(module):
     # then look for a library file with a version modifier, e.g. libarrow.600.dylib.
     arrow_lib = os.environ.get('MONGO_ARROW_LIBDIR', pa.get_library_dirs()[0])
     if platform == "darwin":
-        exts = ['.dylib', r'.(\d+).dylib']
+        exts = ['.dylib$', r'.(\d+).dylib$']
     elif platform == 'linux':
-        exts = ['.so', r'.so.(\d+)']
+        exts = ['.so$', r'.so.(\d+)$']
 
     # Find the appropriate library file and optionally copy it locally.
     # If the library file has a version modifier, use the modifier in the library

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -1,15 +1,12 @@
 import shutil
 from setuptools import setup
-from Cython.Build import cythonize
 
 import glob
 import os
 import subprocess
 from sys import platform
+import sys
 import warnings
-
-import numpy as np
-import pyarrow as pa
 
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -65,6 +62,9 @@ def append_libbson_flags(module):
 
 
 def append_arrow_flags(module):
+    import numpy as np
+    import pyarrow as pa
+
     module.include_dirs.append(np.get_include())
     module.include_dirs.append(pa.get_include())
     module.library_dirs.extend(pa.get_library_dirs())
@@ -99,6 +99,10 @@ def append_arrow_flags(module):
 
 
 def get_extension_modules():
+    try:
+        from Cython.Build import cythonize
+    except ImportError:
+        return []
     modules = cythonize(['pymongoarrow/*.pyx'])
     for module in modules:
         append_libbson_flags(module)

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -99,7 +99,10 @@ def append_arrow_flags(module):
                 match = re.match(pattern, fname)
                 if not match:
                     continue
-                module.libraries.append(name + '.' + match.groups()[0])
+                if match.groups():
+                    module.libraries.append(name + '.' + match.groups()[0])
+                else:
+                    module.libraries.append(name)
                 matched = True
                 # You can use MONGO_NO_COPY_ARROW_LIB to avoid copying the arrow library
                 # files to the build directory (for instance in a conda build).

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -83,9 +83,9 @@ def append_arrow_flags(module):
     else:
         arrow_lib = pa.get_library_dirs()[0]
         if platform == "darwin":
-            pattern = '.*.dylib'
+            pattern = '*.dylib'
         elif platform == 'linux':
-            pattern = '.*.so.*'
+            pattern = '*.so.*'
 
     # Handle linking and optionally copy the library files
     for name in ['libarrow', 'libarrow_python']:


### PR DESCRIPTION
- [x] Modernize to use PEP517-compliant build system
- [x] Copy the arrow libs independently in wheel (but allow it to be overridden for conda-forge so we can use `arrow-cpp`)
- [x] Link to the arrow library files directly instead of using `pyarrow.create_library_symlinks()`
- [x] Updated docs
- [x] Tested locally using a conda [recipe](https://gist.github.com/blink1073/b56e7f1389a2b54fd357d96e544398f7)
