### PR TITLE
ARROW-74 Add support and testing for NumPy

### DIFF
--- a/bindings/python/benchmark.py
+++ b/bindings/python/benchmark.py
@@ -34,6 +34,7 @@ raw_bsons = {}
 
 arrow_tables = {}
 pandas_tables = {}
+numpy_arrays = {}
 
 
 def _setup():
@@ -95,6 +96,8 @@ def _setup():
     arrow_tables[LARGE] = find_arrow_all(db[collection_names[LARGE]], {}, schema=schemas[LARGE])
     pandas_tables[SMALL] = find_pandas_all(db[collection_names[SMALL]], {}, schema=schemas[SMALL])
     pandas_tables[LARGE] = find_pandas_all(db[collection_names[LARGE]], {}, schema=schemas[LARGE])
+    numpy_arrays[SMALL] = find_numpy_all(db[collection_names[SMALL]], {}, schema=schemas[SMALL])
+    numpy_arrays[LARGE] = find_numpy_all(db[collection_names[LARGE]], {}, schema=schemas[LARGE])
 
 
 def _teardown():
@@ -170,6 +173,11 @@ def insert_conventional(use_large):
 @bench("insert_pandas")
 def insert_pandas(use_large):
     write(db[collection_names[use_large]], pandas_tables[use_large])
+
+
+@bench("insert_numpy")
+def insert_numpy(use_large):
+    write(db[collection_names[use_large]], numpy_arrays[use_large])
 
 
 parser = argparse.ArgumentParser(

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -292,6 +292,10 @@ def write(collection, tabular):
     :Returns:
       An instance of :class:`result.ArrowWriteResult`.
     """
+    cur_offset = 0
+    results = {
+        "insertedCount": 0,
+    }
     tab_size = len(tabular)
     if isinstance(tabular, Table):
         _validate_schema(tabular.schema.types)
@@ -304,10 +308,9 @@ def write(collection, tabular):
     ):
         _validate_schema([i.dtype for i in tabular.values()])
         tab_size = len(next(iter(tabular.values())))
-    cur_offset = 0
-    results = {
-        "insertedCount": 0,
-    }
+    else:
+        raise ArrowWriteError(results)
+
     tabular_gen = _tabular_generator(tabular)
     while cur_offset < tab_size:
         cur_size = 0

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -273,10 +273,10 @@ def _tabular_generator(tabular):
         for row in tabular.to_dict("records"):
             yield row
     elif isinstance(tabular, dict):
-        iter_dict = {k: iter(v.tolist()) for k, v in tabular.items()}
+        iter_dict = {k: np.nditer(v) for k, v in tabular.items()}
         while True:
             try:
-                yield {k: next(i) for k, i in iter_dict.items()}
+                yield {k: next(i).item() for k, i in iter_dict.items()}
             except StopIteration:
                 break
 

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -310,7 +310,7 @@ def write(collection, tabular):
         tab_size = len(next(iter(tabular.values())))
     else:
         raise ValueError(
-            f"You passed an invalid tabular data object of type {type(tabular)} \n"
+            f"Invalid tabular data object of type {type(tabular)} \n"
             "Please ensure that it is one of the supported types: "
             "DataFrame, Table, or a dictionary containing NumPy arrays."
         )

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -274,11 +274,11 @@ def _tabular_generator(tabular):
             yield row
     elif isinstance(tabular, dict):
         iter_dict = {k: np.nditer(v) for k, v in tabular.items()}
-        while True:
-            try:
+        try:
+            while True:
                 yield {k: next(i).item() for k, i in iter_dict.items()}
-            except StopIteration:
-                break
+        except StopIteration:
+            return
 
 
 def write(collection, tabular):

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -309,7 +309,11 @@ def write(collection, tabular):
         _validate_schema([i.dtype for i in tabular.values()])
         tab_size = len(next(iter(tabular.values())))
     else:
-        raise ArrowWriteError(results)
+        raise ValueError(
+            f"You passed an invalid tabular data object of type {type(tabular)} \n"
+            "Please ensure that it is one of the supported types: "
+            "DataFrame, Table, or a dictionary containing NumPy arrays."
+        )
 
     tabular_gen = _tabular_generator(tabular)
     while cur_offset < tab_size:

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -300,10 +300,10 @@ def write(collection, tabular):
     elif (
         isinstance(tabular, dict)
         and len(tabular.values()) >= 1
-        and isinstance(list(tabular.values())[0], ndarray)
+        and all([isinstance(i, ndarray) for i in tabular.values()])
     ):
         _validate_schema([i.dtype for i in tabular.values()])
-        tab_size = len(list(tabular.values())[0])
+        tab_size = len(next(iter(tabular.values())))
     cur_offset = 0
     results = {
         "insertedCount": 0,

--- a/bindings/python/pymongoarrow/types.py
+++ b/bindings/python/pymongoarrow/types.py
@@ -14,6 +14,8 @@
 import enum
 from datetime import datetime
 
+import numpy as np
+import pyarrow as pa
 import pyarrow.types as _atypes
 from bson import Int64, ObjectId
 from pyarrow import DataType as _ArrowDataType
@@ -64,6 +66,24 @@ _TYPE_NORMALIZER_FACTORY = {
 }
 
 
+_TYPE_CHECKER_TO_NUMPY = {
+    _atypes.is_int32: np.int32,
+    _atypes.is_int64: np.int64,
+    _atypes.is_float64: np.float64,
+    _atypes.is_timestamp: "datetime64[ms]",
+    _is_objectid: np.object,
+    _atypes.is_string: np.str_,
+    _atypes.is_boolean: np.bool_,
+}
+
+
+def get_numpy_type(type):
+    for checker, comp_type in _TYPE_CHECKER_TO_NUMPY.items():
+        if checker(type):
+            return comp_type
+    return None
+
+
 _TYPE_CHECKER_TO_INTERNAL_TYPE = {
     _atypes.is_int32: _BsonArrowTypes.int32,
     _atypes.is_int64: _BsonArrowTypes.int64,
@@ -105,6 +125,11 @@ def _get_internal_typemap(typemap):
 
 
 def _in_type_map(t):
+    if isinstance(t, np.dtype):
+        try:
+            t = pa.from_numpy_dtype(t)
+        except pa.lib.ArrowNotImplementedError:
+            return False
     for checker in _TYPE_CHECKER_TO_INTERNAL_TYPE.keys():
         if checker(t):
             return True

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -17,7 +17,7 @@ from test import client_context
 from test.utils import AllowListEventListener
 
 import pymongo
-from pyarrow import Table, bool_, decimal128, float64, int32, int64
+from pyarrow import Table, bool_, decimal256, float64, int32, int64
 from pyarrow import schema as ArrowSchema
 from pyarrow import string, timestamp
 from pymongo import DESCENDING, WriteConcern
@@ -227,7 +227,7 @@ class TestArrowApiMixin:
         )
         self.round_trip(data, Schema(schema))
 
-        schema = {"_id": int32(), "data": decimal128(2)}
+        schema = {"_id": int32(), "data": decimal256(2)}
         data = Table.from_pydict(
             {"_id": [i for i in range(2)], "data": [i for i in range(2)]},
             ArrowSchema(schema),

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -48,10 +48,9 @@ class TestExplicitNumPyApi(unittest.TestCase):
         self.cmd_listener.reset()
         self.getmore_listener.reset()
 
-    def assert_numpy_equal(self, actual, expected, schema=None):
+    def assert_numpy_equal(self, actual, expected):
         self.assertIsInstance(actual, dict)
-        for field in schema or self.schema:
-            # print(set(actual)-set(e))
+        for field in expected:
             # workaround np.nan == np.nan evaluating to False
             a = np.nan_to_num(actual[field])
             e = np.nan_to_num(expected[field])
@@ -102,7 +101,7 @@ class TestExplicitNumPyApi(unittest.TestCase):
         coll.drop()
         res = write(self.coll, data)
         self.assertEqual(len(list(data.values())[0]), res.raw_result["insertedCount"])
-        self.assert_numpy_equal(find_numpy_all(coll, {}, schema=schema), data, schema=schema)
+        self.assert_numpy_equal(find_numpy_all(coll, {}, schema=schema), data)
         return res
 
     def schemafied_ndarray_dict(self, dict, schema):

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -83,7 +83,7 @@ class TestExplicitNumPyApi(unittest.TestCase):
     def test_aggregate_simple(self):
         expected = {
             "_id": np.array([1, 2, 3, 4], dtype=np.int32),
-            "data": np.array([20, 40, 60, np.nan], dtype=np.float64),
+            "data": np.array([20, 40, 60, None], dtype=np.float64),
         }
         projection = {"_id": True, "data": {"$multiply": [2, "$data"]}}
         actual = aggregate_numpy_all(self.coll, [{"$project": projection}], schema=self.schema)
@@ -177,5 +177,7 @@ class TestExplicitNumPyApi(unittest.TestCase):
         self.assertEqual(mock.call_count, 2)
 
     def test_write_dictionaries(self):
-        with self.assertRaises(ArrowWriteError):
+        with self.assertRaisesRegex(
+            ValueError, "You passed an invalid tabular data object of type <class 'dict'>"
+        ):
             write(self.coll, {"foo": 1})

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -175,3 +175,7 @@ class TestExplicitNumPyApi(unittest.TestCase):
             coll=self.coll,
         )
         self.assertEqual(mock.call_count, 2)
+
+    def test_write_dictionaries(self):
+        with self.assertRaises(ArrowWriteError):
+            write(self.coll, {"foo": 1})

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -178,6 +178,6 @@ class TestExplicitNumPyApi(unittest.TestCase):
 
     def test_write_dictionaries(self):
         with self.assertRaisesRegex(
-            ValueError, "You passed an invalid tabular data object of type <class 'dict'>"
+            ValueError, "Invalid tabular data object of type <class 'dict'>"
         ):
             write(self.coll, {"foo": 1})

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -15,11 +15,14 @@
 import unittest
 from test import client_context
 from test.utils import AllowListEventListener
+from unittest import mock
 
 import numpy as np
-from pyarrow import int32, int64
+from pyarrow import bool_, float64, int32, int64, string, timestamp
 from pymongo import DESCENDING, WriteConcern
-from pymongoarrow.api import Schema, aggregate_numpy_all, find_numpy_all
+from pymongo.collection import Collection
+from pymongoarrow.api import Schema, aggregate_numpy_all, find_numpy_all, write
+from pymongoarrow.errors import ArrowWriteError
 
 
 class TestExplicitNumPyApi(unittest.TestCase):
@@ -45,13 +48,14 @@ class TestExplicitNumPyApi(unittest.TestCase):
         self.cmd_listener.reset()
         self.getmore_listener.reset()
 
-    def assert_numpy_equal(self, actual, expected):
+    def assert_numpy_equal(self, actual, expected, schema=None):
         self.assertIsInstance(actual, dict)
-        for field in self.schema:
+        for field in schema or self.schema:
+            # print(set(actual)-set(e))
             # workaround np.nan == np.nan evaluating to False
             a = np.nan_to_num(actual[field])
             e = np.nan_to_num(expected[field])
-            self.assertTrue(np.all(a == e))
+            np.testing.assert_array_equal(a, e)
             self.assertEqual(actual[field].dtype, expected[field].dtype)
 
     def test_find_simple(self):
@@ -91,3 +95,84 @@ class TestExplicitNumPyApi(unittest.TestCase):
         assert len(agg_cmd.command["pipeline"]) == 2
         self.assertEqual(agg_cmd.command["pipeline"][0]["$project"], projection)
         self.assertEqual(agg_cmd.command["pipeline"][1]["$project"], {"_id": True, "data": True})
+
+    def round_trip(self, data, schema, coll=None):
+        if coll is None:
+            coll = self.coll
+        coll.drop()
+        res = write(self.coll, data)
+        self.assertEqual(len(list(data.values())[0]), res.raw_result["insertedCount"])
+        self.assert_numpy_equal(find_numpy_all(coll, {}, schema=schema), data, schema=schema)
+        return res
+
+    def schemafied_ndarray_dict(self, dict, schema):
+        ret = {}
+        for k, v in dict.items():
+            ret[k] = np.array(v, dtype=schema[k])
+        return ret
+
+    def test_write_error(self):
+        schema = {"_id": "int32", "data": "int64"}
+        length = 10001
+        data = {"_id": [i for i in range(length)] * 2, "data": [i * 2 for i in range(length)] * 2}
+        data = self.schemafied_ndarray_dict(data, schema)
+        with self.assertRaises(ArrowWriteError):
+            try:
+                self.round_trip(data, Schema({"_id": int32(), "data": int64()}))
+            except ArrowWriteError as awe:
+                self.assertEqual(
+                    10001, awe.details["writeErrors"][0]["index"], awe.details["nInserted"]
+                )
+                raise awe
+
+    def test_write_schema_validation(self):
+        schema = {
+            "data": "int64",
+            "float": "float64",
+            "datetime": "datetime64[ms]",
+            "string": "str",
+            "bool": "bool",
+        }
+        data = {
+            "data": [i for i in range(2)],
+            "float": [i for i in range(2)],
+            "datetime": [i for i in range(2)],
+            "string": [str(i) for i in range(2)],
+            "bool": [True for _ in range(2)],
+        }
+        data = self.schemafied_ndarray_dict(data, schema)
+        self.round_trip(
+            data,
+            Schema(
+                {
+                    "data": int64(),
+                    "float": float64(),
+                    "datetime": timestamp("ms"),
+                    "string": string(),
+                    "bool": bool_(),
+                }
+            ),
+        )
+
+        schema = {"_id": "int32", "data": np.ubyte()}
+        data = {"_id": [i for i in range(2)], "data": [i for i in range(2)]}
+        data = self.schemafied_ndarray_dict(data, schema)
+        with self.assertRaises(ValueError):
+            self.round_trip(data, Schema({"_id": int32(), "data": np.ubyte()}))
+
+    @mock.patch.object(Collection, "insert_many", side_effect=Collection.insert_many, autospec=True)
+    def test_write_batching(self, mock):
+        schema = {"_id": "int64"}
+        data = {"_id": [i for i in range(100040)]}
+        data = self.schemafied_ndarray_dict(data, schema)
+
+        self.round_trip(
+            data,
+            Schema(
+                {
+                    "_id": int64(),
+                }
+            ),
+            coll=self.coll,
+        )
+        self.assertEqual(mock.call_count, 2)

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -19,7 +19,7 @@ from test.utils import AllowListEventListener
 
 import numpy as np
 import pandas as pd
-from pyarrow import bool_, decimal128, float64, int32, int64, string, timestamp
+from pyarrow import bool_, decimal256, float64, int32, int64, string, timestamp
 from pymongo import DESCENDING, WriteConcern
 from pymongo.collection import Collection
 from pymongoarrow.api import Schema, aggregate_pandas_all, find_pandas_all, write
@@ -140,7 +140,7 @@ class TestExplicitPandasApi(unittest.TestCase):
             data={"_id": [i for i in range(2)], "data": [i for i in range(2)]}
         ).astype(schema)
         with self.assertRaises(ValueError):
-            self.round_trip(data, Schema({"_id": int32(), "data": decimal128(2)}))
+            self.round_trip(data, Schema({"_id": int32(), "data": decimal256(2)}))
 
     @mock.patch.object(Collection, "insert_many", side_effect=Collection.insert_many, autospec=True)
     def test_write_batching(self, mock):


### PR DESCRIPTION
Benchmark results:
```
(python3.8) ➜  python git:(ARROW-74) ✗ python benchmark.py

100000 small docs, 40 bytes each with 3 keys
1000 large docs, 153k each with 2600 keys

                    BENCH:   SMALL   LARGE
  conventional-to-ndarray:    0.20    1.13 
    pymongoarrow-to-numpy:    0.29    1.69 
   conventional-to-pandas:    0.26    1.74 
   pymongoarrow-to-pandas:    0.28    1.67 
    pymongoarrow-to-arrow:    0.28    1.67 
             insert_arrow:    1.79    4.78 
      insert_conventional:    1.86    4.86 
            insert_pandas:    2.24    5.04 
             insert_numpy:    2.15    4.66 
```