### PR TITLE
ARROW-94 Test for nulls

### DIFF
--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -426,8 +426,7 @@ class TestNulls(unittest.TestCase):
     def test_int_handling(self):
         # Default integral types
         int_schema = Schema({"_id": ObjectIdType(), "int64": int64()})
-        int64s = [(i if (i % 2 == 0) else None) for i in range(len(
-            self.oids))]
+        int64s = [(i if (i % 2 == 0) else None) for i in range(len(self.oids))]
         self.coll.insert_many(
             [{"_id": self.oids[i], "int64": int64s[i]} for i in range(len(self.oids))]
         )
@@ -443,21 +442,18 @@ class TestNulls(unittest.TestCase):
 
     def test_other_handling(self, na_safe=True, dtype="O"):
         # generating fn, arrow type, numpy dtype
-        other_pairs = [(str, string(), "O"),
-                       (int, int32(), ">i4"),
-                       (float, float64(), "d"),
-                       (lambda x: datetime.datetime(x + 1, 1, 1),
-                        timestamp("ms"),
-                        "datetime64[ms]"),
-                       (lambda _: ObjectId(), ObjectIdType(),
-                        "O"),
-                       (lambda x: Decimal128(str(x)), Decimal128StringType(),
-                        "O")]
+        other_pairs = [
+            (str, string(), "O"),
+            (int, int32(), ">i4"),
+            (float, float64(), "d"),
+            (lambda x: datetime.datetime(x + 1, 1, 1), timestamp("ms"), "datetime64[ms]"),
+            (lambda _: ObjectId(), ObjectIdType(), "O"),
+            (lambda x: Decimal128(str(x)), Decimal128StringType(), "O"),
+        ]
 
         for gen, atype, dtype in other_pairs:
             other_schema = Schema({"_id": ObjectIdType(), "other": atype})
-            others = [gen(i) if (i % 2 == 0) else None for i in range(len(
-                self.oids))]
+            others = [gen(i) if (i % 2 == 0) else None for i in range(len(self.oids))]
 
             self.setUp()
 

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -11,18 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import datetime
 import os
 import unittest
 import unittest.mock as mock
 from test import client_context
 from test.utils import AllowListEventListener
 
-import numpy as np
 import pyarrow
 import pymongo
 from bson import Decimal128, ObjectId
-from pandas import isna
 from pyarrow import Table, binary, bool_, decimal256, float64, int32, int64
 from pyarrow import schema as ArrowSchema
 from pyarrow import string, timestamp
@@ -37,6 +34,8 @@ from pymongoarrow.types import (
     Decimal128StringType,
     ObjectIdType,
 )
+
+from .utils import TestNullsBase
 
 
 class TestArrowApiMixin:
@@ -390,7 +389,7 @@ class TestBSONTypes(unittest.TestCase):
         self.assertEqual(table, expected)
 
 
-class TestNulls(unittest.TestCase):
+class TestNulls(TestNullsBase):
     def find_fn(self, coll, query, schema):
         return find_arrow_all(coll, query, schema=schema)
 
@@ -405,166 +404,3 @@ class TestNulls(unittest.TestCase):
 
     def na_safe(self, atype):
         return True
-
-    # Map Python types to constructors
-    pytype_cons_map = {
-        str: str,
-        int: int,
-        float: float,
-        datetime.datetime: lambda x: datetime.datetime(x + 1970, 1, 1),
-        ObjectId: lambda _: ObjectId(),
-        Decimal128: lambda x: Decimal128(str(x)),
-    }
-
-    # Map Python types to types for table we are comparing.
-    pytype_tab_map = {
-        str: string(),
-        int: int64(),
-        float: float64(),
-        datetime.datetime: timestamp("ms"),
-        ObjectId: ObjectIdType(),
-        Decimal128: Decimal128StringType(),
-        bool: bool_(),
-    }
-
-    pytype_writeback_exc_map = {
-        str: None,
-        int: None,
-        float: None,
-        datetime.datetime: None,
-        ObjectId: pyarrow.lib.ArrowInvalid,
-        Decimal128: pyarrow.lib.ArrowInvalid,
-        bool: None,
-    }
-
-    @classmethod
-    def setUpClass(cls):
-        if not client_context.connected:
-            raise unittest.SkipTest("cannot connect to MongoDB")
-        cls.cmd_listener = AllowListEventListener("find", "aggregate")
-        cls.getmore_listener = AllowListEventListener("getMore")
-        cls.client = client_context.get_client(
-            event_listeners=[cls.getmore_listener, cls.cmd_listener]
-        )
-
-        cls.oids = [ObjectId() for _ in range(4)]
-        cls.coll = cls.client.pymongoarrow_test.get_collection(
-            "test", write_concern=WriteConcern(w="majority")
-        )
-
-    def setUp(self):
-        self.coll.drop()
-
-        self.cmd_listener.reset()
-        self.getmore_listener.reset()
-
-    def assertType(self, obj1, arrow_type):
-        if isinstance(obj1, pyarrow.ChunkedArray):
-            if "storage_type" in dir(arrow_type):
-                self.assertEqual(obj1.type, arrow_type.storage_type)
-            else:
-                self.assertEqual(obj1.type, arrow_type)
-        else:
-            if isinstance(arrow_type, list):
-                self.assertTrue(obj1.dtype.name in arrow_type)
-            else:
-                self.assertEqual(obj1.dtype.name, arrow_type)
-
-    def test_int_handling(self):
-        # Default integral types
-        int_schema = Schema({"_id": ObjectIdType(), "int64": int64()})
-        int64_arr = [(i if (i % 2 == 0) else None) for i in range(len(self.oids))]
-        self.coll.insert_many(
-            [{"_id": self.oids[i], "int64": int64_arr[i]} for i in range(len(self.oids))]
-        )
-
-        table = self.find_fn(self.coll, {}, schema=int_schema)
-
-        # Resulting datatype should be float64 according to the spec for numpy
-        # and pandas.
-        atype = type(self).pytype_tab_map[int]
-        self.assertType(table["int64"], atype)
-
-        # Does it contain NAs where we expect?
-        self.assertTrue(np.all(np.equal(isna(int64_arr), isna(table["int64"]))))
-
-        # Write
-        self.coll.drop()
-        table_write = self.table_from_dict({"int64": int64_arr})
-
-        write(self.coll, table_write)
-        res_table = self.find_fn(self.coll, {}, schema=int_schema)
-
-        self.equal_fn(res_table["int64"], table_write["int64"])
-        self.assert_in_idx(res_table, "_id")
-        self.assertType(res_table["int64"], atype)
-
-    def test_other_handling(self):
-        # Tests other types, which are treated differently in
-        # arrow/pandas/numpy.
-        for gen in [str, float, datetime.datetime, ObjectId, Decimal128]:
-            con_type = type(self).pytype_tab_map[gen]  # Arrow/Pandas/Numpy
-            pytype = TestNulls.pytype_tab_map[gen]  # Arrow type specifically
-
-            other_schema = Schema({"_id": ObjectIdType(), "other": pytype})
-            others = [
-                type(self).pytype_cons_map[gen](i) if (i % 2 == 0) else None
-                for i in range(len(self.oids))
-            ]
-
-            self.setUp()
-            self.coll.insert_many(
-                [{"_id": self.oids[i], "other": others[i]} for i in range(len(self.oids))]
-            )
-            table = self.find_fn(self.coll, {}, schema=other_schema)
-
-            # Resulting datatype should be str in this case
-
-            self.assertType(table["other"], con_type)
-            self.assertEqual(
-                self.na_safe(con_type), np.all(np.equal(isna(others), isna(table["other"])))
-            )
-
-            def writeback():
-                # Write
-                self.coll.drop()
-                table_write_schema = Schema({"other": pytype})
-                table_write_schema_arrow = (
-                    pyarrow.schema([("other", pytype)])
-                    if (gen in [str, float, datetime.datetime])
-                    else None
-                )
-
-                table_write = self.table_from_dict(
-                    {"other": others}, schema=table_write_schema_arrow
-                )
-
-                write(self.coll, table_write)
-                res_table = self.find_fn(self.coll, {}, schema=table_write_schema)
-                self.equal_fn(res_table, table_write)
-                self.assertType(res_table["other"], con_type)
-
-            # Do we expect an exception to be raised?
-            if type(self).pytype_writeback_exc_map[gen] is not None:
-                expected_exc = type(self).pytype_writeback_exc_map[gen]
-                with self.assertRaises(expected_exc):
-                    writeback()
-            else:
-                writeback()
-
-    def test_bool_handling(self):
-        atype = type(self).pytype_tab_map[bool]
-        bool_schema = Schema({"_id": ObjectIdType(), "bool_": bool_()})
-        bools = [True if (i % 2 == 0) else None for i in range(len(self.oids))]
-
-        self.coll.insert_many(
-            [{"_id": self.oids[i], "bool_": bools[i]} for i in range(len(self.oids))]
-        )
-
-        table = self.find_fn(self.coll, {}, schema=bool_schema)
-
-        # Resulting datatype should be object
-        self.assertType(table["bool_"], atype)
-
-        # Does it contain Nones where expected?
-        self.assertTrue(np.all(np.equal(isna(bools), isna(table["bool_"]))))

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -519,7 +519,8 @@ class TestNulls(unittest.TestCase):
                 self.na_safe(atype), np.all(np.equal(isna(others), isna(table["other"])))
             )
 
-            if gen in [ObjectId, Decimal128]:
+            # These are generally not writable with regular items or nulls.
+            if gen in [ObjectId, Decimal128, datetime.datetime]:
                 continue
 
             # Write

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -15,7 +15,7 @@ import os
 import unittest
 import unittest.mock as mock
 from test import client_context
-from test.utils import AllowListEventListener
+from test.utils import AllowListEventListener, TestNullsBase
 
 import pyarrow
 import pymongo
@@ -34,8 +34,6 @@ from pymongoarrow.types import (
     Decimal128StringType,
     ObjectIdType,
 )
-
-from .utils import TestNullsBase
 
 
 class TestArrowApiMixin:

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -15,7 +15,7 @@
 import datetime
 import unittest
 from test import client_context
-from test.utils import AllowListEventListener
+from test.utils import AllowListEventListener, TestNullsBase
 from unittest import mock
 
 import numpy as np
@@ -30,8 +30,6 @@ from pymongoarrow.types import (
     Decimal128StringType,
     ObjectIdType,
 )
-
-from .utils import TestNullsBase
 
 
 class NumpyTestBase(unittest.TestCase):

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -15,7 +15,6 @@
 import datetime
 import unittest
 from test import client_context
-from test.test_arrow import TestNulls as TestNullsBase
 from test.utils import AllowListEventListener
 from unittest import mock
 
@@ -31,6 +30,8 @@ from pymongoarrow.types import (
     Decimal128StringType,
     ObjectIdType,
 )
+
+from .utils import TestNullsBase
 
 
 class NumpyTestBase(unittest.TestCase):

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import numpy as np
 from bson import Decimal128, ObjectId
-from pyarrow import int32, int64
+from pyarrow import int32, int64, string
 from pymongo import DESCENDING, WriteConcern
 from pymongo.collection import Collection
 from pymongoarrow.api import Schema, aggregate_numpy_all, find_numpy_all, write
@@ -252,5 +252,11 @@ class TestNulls(TestNullsBase):
     def setUpClass(cls, find_fn=find_numpy_all):
         super().setUpClass(find_fn)
 
-    def test_other_handling(self, na_safe=False, dtype="<U4"):
-        super().test_other_handling(na_safe, dtype)
+    @staticmethod
+    def _other_na_safe(atype):
+        return atype != string()
+
+    def test_other_handling(self, na_safe=_other_na_safe):
+        super().test_other_handling(
+            na_safe, str_dtype="<U4", oid_dtype="O", d128_dtype="O", dt_dtype="<M8[ms]"
+        )

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -248,9 +248,18 @@ class TestBSONTypes(NumpyTestBase):
 # The spec for pyarrow says to_numpy is experimental, so we should expect
 # this to change in the future.
 class TestNulls(TestNullsBase):
+    @staticmethod
+    def numpy_dict(d):
+        return {k: np.array(v, dtype=np.float_) for k, v in d.items()}
+
     @classmethod
-    def setUpClass(cls, find_fn=find_numpy_all):
-        super().setUpClass(find_fn)
+    def setUpClass(
+        cls,
+        find_fn=find_numpy_all,
+        equal_fn=NumpyTestBase.assert_numpy_equal,
+        table_from_dict=numpy_dict,
+    ):
+        super().setUpClass(find_fn, equal_fn, table_from_dict)
 
     @staticmethod
     def _other_na_safe(atype):

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -14,12 +14,13 @@
 # from datetime import datetime, timedelta
 import unittest
 from test import client_context
+from test.test_arrow import TestNulls as TestNullsBase
 from test.utils import AllowListEventListener
 from unittest import mock
 
 import numpy as np
 from bson import Decimal128, ObjectId
-from pyarrow import int32, int64, string, bool_
+from pyarrow import int32, int64
 from pymongo import DESCENDING, WriteConcern
 from pymongo.collection import Collection
 from pymongoarrow.api import Schema, aggregate_numpy_all, find_numpy_all, write
@@ -29,8 +30,6 @@ from pymongoarrow.types import (
     Decimal128StringType,
     ObjectIdType,
 )
-
-from test.test_arrow import TestNulls as TestNullsBase
 
 
 class NumpyTestBase(unittest.TestCase):

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -29,7 +29,9 @@ from pymongoarrow.types import (
     Decimal128StringType,
     ObjectIdType,
 )
-from pandas import isna # Uses isna for non numpy types
+
+from test.test_arrow import TestNulls as TestNullsBase
+
 
 class NumpyTestBase(unittest.TestCase):
     @classmethod
@@ -244,77 +246,12 @@ class TestBSONTypes(NumpyTestBase):
         self.assert_numpy_equal(actual, expected)
 
 
-
 # The spec for pyarrow says to_numpy is experimental, so we should expect
 # this to change in the future.
-class TestNulls(NumpyTestBase):
+class TestNulls(TestNullsBase):
     @classmethod
-    def setUpClass(cls):
-        NumpyTestBase.setUpClass()
+    def setUpClass(cls, find_fn=find_numpy_all):
+        super().setUpClass(find_fn)
 
-        cls.coll = cls.client.pymongoarrow_test.get_collection(
-            "test", write_concern=WriteConcern(w="majority")
-        )
-        cls.oids = [ObjectId() for i in range(4)]
-
-
-    def setUp(self):
-        self.coll.drop()
-
-        self.cmd_listener.reset()
-        self.getmore_listener.reset()
-
-    def test_int_handling(self):
-        self.schema = Schema({"_id": ObjectIdType(), "int32": int32()})
-        self.int32s = [(i if (i % 2 == 0) else None) for i in range(len(
-            self.oids))]
-        self.coll.insert_many(
-            [{"_id": self.oids[i], "int32": self.int32s[i]} for i in range(
-                len(self.oids))]
-        )
-
-        table = find_numpy_all(self.coll, {}, schema=self.schema)
-
-        # Resulting datatype should be float64 according to the spec
-        self.assertEqual(table["int32"].dtype, np.dtype("float64"))
-
-        # Does it contain NAs where we expect?
-        self.assertTrue(np.all(np.equal(isna(self.int32s),
-                               np.isnan(table["int32"]))))
-
-    def test_bool_handling(self):
-        self.schema = Schema({"_id": ObjectIdType(), "bool_": bool_()})
-        self.bools = [True if (i % 2 == 0) else None for i in range(
-            len(self.oids))]
-        self.coll.insert_many(
-           [{"_id": self.oids[i], "bool_": self.bools[i]} for i in range(len(
-               self.oids))]
-        )
-
-        table = find_numpy_all(self.coll, {}, schema=self.schema)
-
-        # Resulting datatype should be object
-        self.assertEqual(table["bool_"].dtype, np.dtype("O"))
-
-        # Does it contain Nones where expected?
-        self.assertTrue(np.all(np.equal(isna(self.bools),
-                                        isna(table["bool_"]))))
-
-    def test_other_handling(self):
-        self.schema = Schema({"_id": ObjectIdType(), "other": string()})
-        self.others = [str(i) if (i % 2 == 0) else None for i in range(
-            len(self.oids))]
-        self.coll.insert_many(
-           [{"_id": self.oids[i], "other": self.others[i]} for i in range(len(
-               self.oids))]
-        )
-
-        table = find_numpy_all(self.coll, {}, schema=self.schema)
-
-        # Resulting datatype should be str in this case
-        self.assertEqual(table["other"].dtype, np.dtype("<U4"))
-
-        # Differs from pandas in that it will convert Nones and will fail
-        # isna, so this should assert False.
-        self.assertFalse(np.all(np.equal(isna(self.others),
-                               isna(table["other"]))))
+    def test_other_handling(self, na_safe=False, dtype="<U4"):
+        super().test_other_handling(na_safe, dtype)

--- a/bindings/python/test/test_numpy.py
+++ b/bindings/python/test/test_numpy.py
@@ -19,7 +19,7 @@ from unittest import mock
 
 import numpy as np
 from bson import Decimal128, ObjectId
-from pyarrow import int32, int64
+from pyarrow import int32, int64, string, bool_
 from pymongo import DESCENDING, WriteConcern
 from pymongo.collection import Collection
 from pymongoarrow.api import Schema, aggregate_numpy_all, find_numpy_all, write
@@ -29,7 +29,7 @@ from pymongoarrow.types import (
     Decimal128StringType,
     ObjectIdType,
 )
-
+from pandas import isna # Uses isna for non numpy types
 
 class NumpyTestBase(unittest.TestCase):
     @classmethod
@@ -242,3 +242,79 @@ class TestBSONTypes(NumpyTestBase):
         }
         actual = find_numpy_all(self.coll, {}, schema=self.schema)
         self.assert_numpy_equal(actual, expected)
+
+
+
+# The spec for pyarrow says to_numpy is experimental, so we should expect
+# this to change in the future.
+class TestNulls(NumpyTestBase):
+    @classmethod
+    def setUpClass(cls):
+        NumpyTestBase.setUpClass()
+
+        cls.coll = cls.client.pymongoarrow_test.get_collection(
+            "test", write_concern=WriteConcern(w="majority")
+        )
+        cls.oids = [ObjectId() for i in range(4)]
+
+
+    def setUp(self):
+        self.coll.drop()
+
+        self.cmd_listener.reset()
+        self.getmore_listener.reset()
+
+    def test_int_handling(self):
+        self.schema = Schema({"_id": ObjectIdType(), "int32": int32()})
+        self.int32s = [(i if (i % 2 == 0) else None) for i in range(len(
+            self.oids))]
+        self.coll.insert_many(
+            [{"_id": self.oids[i], "int32": self.int32s[i]} for i in range(
+                len(self.oids))]
+        )
+
+        table = find_numpy_all(self.coll, {}, schema=self.schema)
+
+        # Resulting datatype should be float64 according to the spec
+        self.assertEqual(table["int32"].dtype, np.dtype("float64"))
+
+        # Does it contain NAs where we expect?
+        self.assertTrue(np.all(np.equal(isna(self.int32s),
+                               np.isnan(table["int32"]))))
+
+    def test_bool_handling(self):
+        self.schema = Schema({"_id": ObjectIdType(), "bool_": bool_()})
+        self.bools = [True if (i % 2 == 0) else None for i in range(
+            len(self.oids))]
+        self.coll.insert_many(
+           [{"_id": self.oids[i], "bool_": self.bools[i]} for i in range(len(
+               self.oids))]
+        )
+
+        table = find_numpy_all(self.coll, {}, schema=self.schema)
+
+        # Resulting datatype should be object
+        self.assertEqual(table["bool_"].dtype, np.dtype("O"))
+
+        # Does it contain Nones where expected?
+        self.assertTrue(np.all(np.equal(isna(self.bools),
+                                        isna(table["bool_"]))))
+
+    def test_other_handling(self):
+        self.schema = Schema({"_id": ObjectIdType(), "other": string()})
+        self.others = [str(i) if (i % 2 == 0) else None for i in range(
+            len(self.oids))]
+        self.coll.insert_many(
+           [{"_id": self.oids[i], "other": self.others[i]} for i in range(len(
+               self.oids))]
+        )
+
+        table = find_numpy_all(self.coll, {}, schema=self.schema)
+
+        # Resulting datatype should be str in this case
+        self.assertEqual(table["other"].dtype, np.dtype("<U4"))
+
+        # Differs from pandas in that it will convert Nones and will fail
+        # isna, so this should assert False.
+        self.assertFalse(np.all(np.equal(isna(self.others),
+                               isna(table["other"]))))

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -22,6 +22,7 @@ from test.utils import AllowListEventListener
 import numpy as np
 import pandas as pd
 import pandas.testing
+import pyarrow
 from bson import Decimal128, ObjectId
 from pyarrow import decimal256, int32, int64
 from pymongo import DESCENDING, WriteConcern
@@ -250,4 +251,14 @@ class TestNulls(TestNullsBase):
         ObjectId: "object",
         Decimal128: "object",
         bool: "object",
+    }
+
+    pytype_writeback_exc_map = {
+        str: None,
+        int: None,
+        float: None,
+        datetime.datetime: ValueError,
+        ObjectId: ValueError,
+        Decimal128: pyarrow.lib.ArrowInvalid,
+        bool: None,
     }

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -16,7 +16,7 @@ import datetime
 import unittest
 import unittest.mock as mock
 from test import client_context
-from test.utils import AllowListEventListener
+from test.utils import AllowListEventListener, TestNullsBase
 
 import numpy as np
 import pandas as pd
@@ -33,8 +33,6 @@ from pymongoarrow.types import (
     Decimal128StringType,
     ObjectIdType,
 )
-
-from .utils import TestNullsBase
 
 
 class PandasTestBase(unittest.TestCase):

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -20,6 +20,7 @@ from test.utils import AllowListEventListener
 
 import numpy as np
 import pandas as pd
+import pandas.testing
 from bson import Decimal128, ObjectId
 from pyarrow import decimal256, int32, int64
 from pymongo import DESCENDING, WriteConcern
@@ -223,9 +224,14 @@ class TestBSONTypes(PandasTestBase):
 
 
 class TestNulls(TestNullsBase):
+    def assert_pandas_equal(self, left, right):
+        pandas.testing.assert_frame_equal(left, right, check_dtype=False)
+
     @classmethod
-    def setUpClass(cls, find_fn=find_pandas_all):
-        super().setUpClass(find_fn)
+    def setUpClass(
+        cls, find_fn=find_pandas_all, equal_fn=assert_pandas_equal, table_from_dict=pandas.DataFrame
+    ):
+        super().setUpClass(find_fn, equal_fn, table_from_dict)
 
     def test_other_handling(self):
         super().test_other_handling(dt_dtype="<M8[ns]")

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -15,12 +15,13 @@
 import unittest
 import unittest.mock as mock
 from test import client_context
+from test.test_arrow import TestNulls as TestNullsBase
 from test.utils import AllowListEventListener
 
 import numpy as np
 import pandas as pd
 from bson import Decimal128, ObjectId
-from pyarrow import decimal256, int32, int64, string, bool_
+from pyarrow import decimal256, int32, int64
 from pymongo import DESCENDING, WriteConcern
 from pymongo.collection import Collection
 from pymongoarrow.api import Schema, aggregate_pandas_all, find_pandas_all, write
@@ -29,10 +30,7 @@ from pymongoarrow.types import (
     _TYPE_NORMALIZER_FACTORY,
     Decimal128StringType,
     ObjectIdType,
-
 )
-
-from test.test_arrow import TestNulls as TestNullsBase
 
 
 class PandasTestBase(unittest.TestCase):

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -230,8 +230,8 @@ class TestNulls(TestNullsBase):
         return find_pandas_all(coll, query, schema=schema)
 
     def equal_fn(self, left, right):
-        left = left.fillna(0)
-        right = right.fillna(0)
+        left = left.fillna(0).replace(-0b1 << 63, 0)  # NaN is sometimes this
+        right = right.fillna(0).replace(-0b1 << 63, 0)
         if type(left) == pandas.DataFrame:
             pandas.testing.assert_frame_equal(left, right, check_dtype=False)
         else:

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -32,6 +32,8 @@ from pymongoarrow.types import (
 
 )
 
+from test.test_arrow import TestNulls as TestNullsBase
+
 
 class PandasTestBase(unittest.TestCase):
     @classmethod
@@ -222,72 +224,7 @@ class TestBSONTypes(PandasTestBase):
         pd.testing.assert_frame_equal(expected, table)
 
 
-class TestNulls(PandasTestBase):
+class TestNulls(TestNullsBase):
     @classmethod
-    def setUpClass(cls):
-        PandasTestBase.setUpClass()
-
-        cls.coll = cls.client.pymongoarrow_test.get_collection(
-            "test", write_concern=WriteConcern(w="majority")
-        )
-        cls.oids = [ObjectId() for i in range(4)]
-
-
-    def setUp(self):
-        self.coll.drop()
-
-        self.cmd_listener.reset()
-        self.getmore_listener.reset()
-
-    def test_int_handling(self):
-        self.schema = Schema({"_id": ObjectIdType(), "int32": int32()})
-        self.int32s = [(i if (i % 2 == 0) else None) for i in range(len(
-            self.oids))]
-        self.coll.insert_many(
-            [{"_id": self.oids[i], "int32": self.int32s[i]} for i in range(
-                len(self.oids))]
-        )
-
-        table = find_pandas_all(self.coll, {}, schema=self.schema)
-
-        # Resulting datatype should be float64 according to the spec
-        self.assertEqual(table["int32"].dtype, np.dtype("float64"))
-
-        # Does it contain NAs where we expect?
-        self.assertTrue(np.all(np.equal(pd.isna(self.int32s),
-                               pd.isna(table["int32"]))))
-
-    def test_bool_handling(self):
-        self.schema = Schema({"_id": ObjectIdType(), "bool_": bool_()})
-        self.bools = [True if (i % 2 == 0) else None for i in range(
-            len(self.oids))]
-        self.coll.insert_many(
-           [{"_id": self.oids[i], "bool_": self.bools[i]} for i in range(len(
-               self.oids))]
-        )
-
-        table = find_pandas_all(self.coll, {}, schema=self.schema)
-
-        # Resulting datatype should be object
-        self.assertEqual(table["bool_"].dtype, np.dtype("O"))
-
-        # Does it contain Nones where expected?
-        self.assertTrue(np.all(np.equal(pd.isna(self.bools),
-                                        pd.isna(table["bool_"]))))
-
-    def test_other_handling(self):
-        self.schema = Schema({"_id": ObjectIdType(), "other": string()})
-        self.others = [str(i) if (i % 2 == 0) else None for i in range(
-            len(self.oids))]
-        self.coll.insert_many(
-           [{"_id": self.oids[i], "other": self.others[i]} for i in range(len(
-               self.oids))]
-        )
-
-        table = find_pandas_all(self.coll, {}, schema=self.schema)
-
-        # Resulting datatype should be str in this case
-        self.assertEqual(table["other"].dtype, np.dtype("O"))
-
-        self.assertTrue(np.all(np.equal(pd.isna(self.others),
-                               pd.isna(table["other"]))))
+    def setUpClass(cls, find_fn=find_pandas_all):
+        super().setUpClass(find_fn)

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -16,7 +16,6 @@ import datetime
 import unittest
 import unittest.mock as mock
 from test import client_context
-from test.test_arrow import TestNulls as TestNullsBase
 from test.utils import AllowListEventListener
 
 import numpy as np
@@ -34,6 +33,8 @@ from pymongoarrow.types import (
     Decimal128StringType,
     ObjectIdType,
 )
+
+from .utils import TestNullsBase
 
 
 class PandasTestBase(unittest.TestCase):
@@ -262,3 +263,6 @@ class TestNulls(TestNullsBase):
         Decimal128: pyarrow.lib.ArrowInvalid,
         bool: None,
     }
+
+    def na_safe(self, atype):
+        return True

--- a/bindings/python/test/test_pandas.py
+++ b/bindings/python/test/test_pandas.py
@@ -226,3 +226,6 @@ class TestNulls(TestNullsBase):
     @classmethod
     def setUpClass(cls, find_fn=find_pandas_all):
         super().setUpClass(find_fn)
+
+    def test_other_handling(self):
+        super().test_other_handling(dt_dtype="<M8[ns]")

--- a/bindings/python/test/utils.py
+++ b/bindings/python/test/utils.py
@@ -162,7 +162,7 @@ class TestNullsBase(unittest.TestCase):
 
         # Resulting datatype should be float64 according to the spec for numpy
         # and pandas.
-        atype = type(self).pytype_tab_map[int]
+        atype = self.pytype_tab_map[int]
         self.assertType(table["int64"], atype)
 
         # Does it contain NAs where we expect?
@@ -183,12 +183,12 @@ class TestNullsBase(unittest.TestCase):
         # Tests other types, which are treated differently in
         # arrow/pandas/numpy.
         for gen in [str, float, datetime.datetime, ObjectId, Decimal128]:
-            con_type = type(self).pytype_tab_map[gen]  # Arrow/Pandas/Numpy
+            con_type = self.pytype_tab_map[gen]  # Arrow/Pandas/Numpy
             pytype = TestNullsBase.pytype_tab_map[gen]  # Arrow type specifically
 
             other_schema = Schema({"_id": ObjectIdType(), "other": pytype})
             others = [
-                type(self).pytype_cons_map[gen](i) if (i % 2 == 0) else None
+                self.pytype_cons_map[gen](i) if (i % 2 == 0) else None
                 for i in range(len(self.oids))
             ]
 
@@ -225,15 +225,15 @@ class TestNullsBase(unittest.TestCase):
                 self.assertType(res_table["other"], con_type)
 
             # Do we expect an exception to be raised?
-            if type(self).pytype_writeback_exc_map[gen] is not None:
-                expected_exc = type(self).pytype_writeback_exc_map[gen]
+            if self.pytype_writeback_exc_map[gen] is not None:
+                expected_exc = self.pytype_writeback_exc_map[gen]
                 with self.assertRaises(expected_exc):
                     writeback()
             else:
                 writeback()
 
     def test_bool_handling(self):
-        atype = type(self).pytype_tab_map[bool]
+        atype = self.pytype_tab_map[bool]
         bool_schema = Schema({"_id": ObjectIdType(), "bool_": bool_()})
         bools = [True if (i % 2 == 0) else None for i in range(len(self.oids))]
 

--- a/bindings/python/test/utils.py
+++ b/bindings/python/test/utils.py
@@ -24,7 +24,12 @@ from pyarrow import bool_, float64, int64, string, timestamp
 from pymongo import WriteConcern, monitoring
 from pymongoarrow.api import write
 from pymongoarrow.schema import Schema
-from pymongoarrow.types import Decimal128StringType, ObjectIdType
+from pymongoarrow.types import (
+    _TYPE_NORMALIZER_FACTORY,
+    Decimal128StringType,
+    ObjectIdType,
+    _in_type_map,
+)
 
 
 class EventListener(monitoring.CommandListener):
@@ -178,6 +183,10 @@ class TestNullsBase(unittest.TestCase):
         self.equal_fn(res_table["int64"], table_write["int64"])
         self.assert_in_idx(res_table, "_id")
         self.assertType(res_table["int64"], atype)
+
+    def test_all_types(self):
+        for t in self.pytype_tab_map.keys():
+            self.assertTrue(_in_type_map(_TYPE_NORMALIZER_FACTORY[t](0)))
 
     def test_other_handling(self):
         # Tests other types, which are treated differently in

--- a/bindings/python/test/utils.py
+++ b/bindings/python/test/utils.py
@@ -11,9 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
+import unittest
 from collections import defaultdict
+from test import client_context
 
-from pymongo import monitoring
+import numpy as np
+import pyarrow
+from bson import Decimal128, ObjectId
+from pandas import isna
+from pyarrow import bool_, float64, int64, string, timestamp
+from pymongo import WriteConcern, monitoring
+from pymongoarrow.api import write
+from pymongoarrow.schema import Schema
+from pymongoarrow.types import Decimal128StringType, ObjectIdType
 
 
 class EventListener(monitoring.CommandListener):
@@ -54,3 +65,186 @@ class AllowListEventListener(EventListener):
     def failed(self, event):
         if event.command_name in self.commands:
             super(AllowListEventListener, self).failed(event)
+
+
+class TestNullsBase(unittest.TestCase):
+    def find_fn(self, coll, query, schema):
+        raise NotImplementedError
+
+    def equal_fn(self, left, right):
+        raise NotImplementedError
+
+    def table_from_dict(self, dict, schema=None):
+        raise NotImplementedError
+
+    def assert_in_idx(self, table, col_name):
+        raise NotImplementedError
+
+    def na_safe(self, atype):
+        raise NotImplementedError
+
+    # Map Python types to constructors
+    pytype_cons_map = {
+        str: str,
+        int: int,
+        float: float,
+        datetime.datetime: lambda x: datetime.datetime(x + 1970, 1, 1),
+        ObjectId: lambda _: ObjectId(),
+        Decimal128: lambda x: Decimal128(str(x)),
+    }
+
+    # Map Python types to types for table we are comparing.
+    pytype_tab_map = {
+        str: string(),
+        int: int64(),
+        float: float64(),
+        datetime.datetime: timestamp("ms"),
+        ObjectId: ObjectIdType(),
+        Decimal128: Decimal128StringType(),
+        bool: bool_(),
+    }
+
+    pytype_writeback_exc_map = {
+        str: None,
+        int: None,
+        float: None,
+        datetime.datetime: None,
+        ObjectId: pyarrow.lib.ArrowInvalid,
+        Decimal128: pyarrow.lib.ArrowInvalid,
+        bool: None,
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        if cls is TestNullsBase:
+            raise unittest.SkipTest("Base class")
+
+        if not client_context.connected:
+            raise unittest.SkipTest("cannot connect to MongoDB")
+        cls.cmd_listener = AllowListEventListener("find", "aggregate")
+        cls.getmore_listener = AllowListEventListener("getMore")
+        cls.client = client_context.get_client(
+            event_listeners=[cls.getmore_listener, cls.cmd_listener]
+        )
+
+        cls.oids = [ObjectId() for _ in range(4)]
+        cls.coll = cls.client.pymongoarrow_test.get_collection(
+            "test", write_concern=WriteConcern(w="majority")
+        )
+
+    def setUp(self):
+        self.coll.drop()
+
+        self.cmd_listener.reset()
+        self.getmore_listener.reset()
+
+    def assertType(self, obj1, arrow_type):
+        if isinstance(obj1, pyarrow.ChunkedArray):
+            if "storage_type" in dir(arrow_type):
+                self.assertEqual(obj1.type, arrow_type.storage_type)
+            else:
+                self.assertEqual(obj1.type, arrow_type)
+        else:
+            if isinstance(arrow_type, list):
+                self.assertTrue(obj1.dtype.name in arrow_type)
+            else:
+                self.assertEqual(obj1.dtype.name, arrow_type)
+
+    def test_int_handling(self):
+        # Default integral types
+        int_schema = Schema({"_id": ObjectIdType(), "int64": int64()})
+        int64_arr = [(i if (i % 2 == 0) else None) for i in range(len(self.oids))]
+        self.coll.insert_many(
+            [{"_id": self.oids[i], "int64": int64_arr[i]} for i in range(len(self.oids))]
+        )
+
+        table = self.find_fn(self.coll, {}, schema=int_schema)
+
+        # Resulting datatype should be float64 according to the spec for numpy
+        # and pandas.
+        atype = type(self).pytype_tab_map[int]
+        self.assertType(table["int64"], atype)
+
+        # Does it contain NAs where we expect?
+        self.assertTrue(np.all(np.equal(isna(int64_arr), isna(table["int64"]))))
+
+        # Write
+        self.coll.drop()
+        table_write = self.table_from_dict({"int64": int64_arr})
+
+        write(self.coll, table_write)
+        res_table = self.find_fn(self.coll, {}, schema=int_schema)
+
+        self.equal_fn(res_table["int64"], table_write["int64"])
+        self.assert_in_idx(res_table, "_id")
+        self.assertType(res_table["int64"], atype)
+
+    def test_other_handling(self):
+        # Tests other types, which are treated differently in
+        # arrow/pandas/numpy.
+        for gen in [str, float, datetime.datetime, ObjectId, Decimal128]:
+            con_type = type(self).pytype_tab_map[gen]  # Arrow/Pandas/Numpy
+            pytype = TestNullsBase.pytype_tab_map[gen]  # Arrow type specifically
+
+            other_schema = Schema({"_id": ObjectIdType(), "other": pytype})
+            others = [
+                type(self).pytype_cons_map[gen](i) if (i % 2 == 0) else None
+                for i in range(len(self.oids))
+            ]
+
+            self.setUp()
+            self.coll.insert_many(
+                [{"_id": self.oids[i], "other": others[i]} for i in range(len(self.oids))]
+            )
+            table = self.find_fn(self.coll, {}, schema=other_schema)
+
+            # Resulting datatype should be str in this case
+
+            self.assertType(table["other"], con_type)
+            self.assertEqual(
+                self.na_safe(con_type), np.all(np.equal(isna(others), isna(table["other"])))
+            )
+
+            def writeback():
+                # Write
+                self.coll.drop()
+                table_write_schema = Schema({"other": pytype})
+                table_write_schema_arrow = (
+                    pyarrow.schema([("other", pytype)])
+                    if (gen in [str, float, datetime.datetime])
+                    else None
+                )
+
+                table_write = self.table_from_dict(
+                    {"other": others}, schema=table_write_schema_arrow
+                )
+
+                write(self.coll, table_write)
+                res_table = self.find_fn(self.coll, {}, schema=table_write_schema)
+                self.equal_fn(res_table, table_write)
+                self.assertType(res_table["other"], con_type)
+
+            # Do we expect an exception to be raised?
+            if type(self).pytype_writeback_exc_map[gen] is not None:
+                expected_exc = type(self).pytype_writeback_exc_map[gen]
+                with self.assertRaises(expected_exc):
+                    writeback()
+            else:
+                writeback()
+
+    def test_bool_handling(self):
+        atype = type(self).pytype_tab_map[bool]
+        bool_schema = Schema({"_id": ObjectIdType(), "bool_": bool_()})
+        bools = [True if (i % 2 == 0) else None for i in range(len(self.oids))]
+
+        self.coll.insert_many(
+            [{"_id": self.oids[i], "bool_": bools[i]} for i in range(len(self.oids))]
+        )
+
+        table = self.find_fn(self.coll, {}, schema=bool_schema)
+
+        # Resulting datatype should be object
+        self.assertType(table["bool_"], atype)
+
+        # Does it contain Nones where expected?
+        self.assertTrue(np.all(np.equal(isna(bools), isna(table["bool_"]))))


### PR DESCRIPTION
Adds unit tests for null value behaviors for pyarrow, numpy, and pandas. Leaves underlying behavior intact.