### PR TITLE
ARROW-107 Test against Python 3.11

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -47,14 +47,12 @@ jobs:
         if: ${{ matrix.python == 'cp38' && matrix.buildplat[0] == 'macos-11' }}
         env:
           CIBW_BUILD: cp38-macosx_x86_64
-          MACOSX_DEPLOYMENT_TARGET: "10.14"
         run: python -m cibuildwheel --output-dir wheelhouse
 
       - name: Build wheels
         if: ${{ matrix.python != 'cp38' || matrix.buildplat[0] != 'macos-11' }}
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
-          MACOSX_DEPLOYMENT_TARGET: "10.14"
         run: python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -47,12 +47,14 @@ jobs:
         if: ${{ matrix.python == 'cp38' && matrix.buildplat[0] == 'macos-11' }}
         env:
           CIBW_BUILD: cp38-macosx_x86_64
+          MACOSX_DEPLOYMENT_TARGET: "10.14"
         run: python -m cibuildwheel --output-dir wheelhouse
 
       - name: Build wheels
         if: ${{ matrix.python != 'cp38' || matrix.buildplat[0] != 'macos-11' }}
         env:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+          MACOSX_DEPLOYMENT_TARGET: "10.14"
         run: python -m cibuildwheel --output-dir wheelhouse
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -30,7 +30,7 @@ jobs:
         - [ubuntu-20.04, manylinux_x86_64]
         - [macos-11, macosx_*]
         - [windows-2019, win_amd64]
-        python: ["cp37", "cp38", "cp39", "cp310"]
+        python: ["cp37", "cp38", "cp39", "cp310", "cp311"]
 
     steps:
       - name: Checkout pymongoarrow

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-20.04", "macos-latest", "windows-latest"]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
       fail-fast: false
     name: CPython ${{ matrix.python-version }}-${{ matrix.os }}
     steps:

--- a/bindings/python/cibw_before_build.sh
+++ b/bindings/python/cibw_before_build.sh
@@ -12,8 +12,8 @@ then
   mac_version="${MACOSX_DEPLOYMENT_TARGET/\./_}"
   if [[ "$ARCHFLAGS" == *"arm64"* ]]
   then
-    platform="macosx_${mac_version}_universal2"
-    export CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+    platform="macosx_${mac_version}_arm64"
+    export CMAKE_OSX_ARCHITECTURES="arm64"
   else
     platform="macosx_${mac_version}_x86_64"
   fi

--- a/bindings/python/cibw_before_build.sh
+++ b/bindings/python/cibw_before_build.sh
@@ -9,12 +9,15 @@ set -o errexit
 
 if [[ "$CIBW_BUILD" == *"macosx_"* ]]
 then
-  mac_version="${MACOSX_DEPLOYMENT_TARGET/\./_}"
   if [[ "$ARCHFLAGS" == *"arm64"* ]]
   then
+    export MACOSX_DEPLOYMENT_TARGET="11.0"
+    mac_version="${MACOSX_DEPLOYMENT_TARGET/\./_}"
     platform="macosx_${mac_version}_arm64"
     export CMAKE_OSX_ARCHITECTURES="arm64"
   else
+    export MACOSX_DEPLOYMENT_TARGET="10.14"
+    mac_version="${MACOSX_DEPLOYMENT_TARGET/\./_}"
     platform="macosx_${mac_version}_x86_64"
   fi
 

--- a/bindings/python/cibw_before_build.sh
+++ b/bindings/python/cibw_before_build.sh
@@ -11,14 +11,10 @@ if [[ "$CIBW_BUILD" == *"macosx_"* ]]
 then
   if [[ "$ARCHFLAGS" == *"arm64"* ]]
   then
-    export MACOSX_DEPLOYMENT_TARGET="11.0"
-    mac_version="${MACOSX_DEPLOYMENT_TARGET/\./_}"
-    platform="macosx_${mac_version}_arm64"
+    platform="macosx_11_0_arm64"
     export CMAKE_OSX_ARCHITECTURES="arm64"
   else
-    export MACOSX_DEPLOYMENT_TARGET="10.14"
-    mac_version="${MACOSX_DEPLOYMENT_TARGET/\./_}"
-    platform="macosx_${mac_version}_x86_64"
+    platform="macosx_10_14_x86_64"
   fi
 
   # Install pyarrow with the appropriate platform.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -19,7 +19,7 @@ repair-wheel-command = ""
 LIBBSON_INSTALL_DIR = "./libbson"
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux_2_17"
+manylinux-x86_64-image = "manylinux_2_17_x86_64"
 repair-wheel-command = [
     "pip install \"auditwheel>=5,<6\"",
     "python addtags.py {wheel} {dest_dir}"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -19,12 +19,12 @@ repair-wheel-command = ""
 LIBBSON_INSTALL_DIR = "./libbson"
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_17"
 repair-wheel-command = [
     "pip install \"auditwheel>=5,<6\"",
     "python addtags.py {wheel} {dest_dir}"
 ]
 
 [tool.cibuildwheel.macos]
-archs = "x86_64 universal2"
-test-skip = "*universal2:arm64"
+archs = "x86_64 arm64"
+test-skip = "*arm64"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -19,7 +19,7 @@ repair-wheel-command = ""
 LIBBSON_INSTALL_DIR = "./libbson"
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux_2_24"
+manylinux-x86_64-image = "manylinux2014"
 repair-wheel-command = [
     "pip install \"auditwheel>=5,<6\"",
     "python addtags.py {wheel} {dest_dir}"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -19,7 +19,7 @@ repair-wheel-command = ""
 LIBBSON_INSTALL_DIR = "./libbson"
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux_2_17_x86_64"
+manylinux-x86_64-image = "manylinux_2_24"
 repair-wheel-command = [
     "pip install \"auditwheel>=5,<6\"",
     "python addtags.py {wheel} {dest_dir}"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel>=0.37",
     "cython>=0.29",
     # Must be kept in sync with the `install_requires` in `setup.cfg`
-    "pyarrow>=10.0.0,<10.1.0",
+    "pyarrow>=10.0.1,<10.1.0",
 ]
 
 [tool.cibuildwheel]

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -35,7 +35,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     # keep versions in sync with pyproject.toml "requires"
-    pyarrow >=10.01,<10.1
+    pyarrow >=10.0.1,<10.1
     pymongo >=3.11,<5
 
 [options.package_data]

--- a/bindings/python/setup.cfg
+++ b/bindings/python/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Database
 
@@ -34,7 +35,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     # keep versions in sync with pyproject.toml "requires"
-    pyarrow >=10,<10.1
+    pyarrow >=10.01,<10.1
     pymongo >=3.11,<5
 
 [options.package_data]


### PR DESCRIPTION
PyArrow 10.0.1 was released with Python 3.11 support.