### PR TITLE
Migrate benchmark tests to ubuntu-22.04

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,7 +29,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/setup.cfg'
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.8.0
+        uses: supercharge/mongodb-github-action@1.9.0
         with:
           mongodb-version: 6.0
       - name: Install pkg-config

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,8 +32,6 @@ jobs:
         uses: supercharge/mongodb-github-action@1.9.0
         with:
           mongodb-version: 6.0
-      - name: Install pkg-config
-        run: brew install pkg-config
       - name: Install libbson
         run: |
           LIBBSON_INSTALL_DIR=$(pwd)/libbson ./build-libbson.sh

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-latest"]
+        os: ["ubuntu-22.04"]
         python-version: ["3.10"]
       fail-fast: false
     steps:
@@ -28,7 +28,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: '**/setup.cfg'
-      - name: Start MongoDB on MacOS
+      - name: Start MongoDB
         run: |
           mkdir data
           mongod --fork --dbpath=$(pwd)/data --logpath=$PWD/mongo.log

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -29,9 +29,9 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/setup.cfg'
       - name: Start MongoDB
-        run: |
-          mkdir data
-          mongod --fork --dbpath=$(pwd)/data --logpath=$PWD/mongo.log
+        uses: supercharge/mongodb-github-action@1.8.0
+        with:
+          mongodb-version: 6.0
       - name: Install pkg-config
         run: brew install pkg-config
       - name: Install libbson


### PR DESCRIPTION
The benchmark runs much faster on ubuntu-22.04 (~5min) vs macOS (~10-15min).