### PR TITLE
ARROW-158 Fix crash when performing auto schema detection on embedded lists and subdocuments

### DIFF
--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -16,6 +16,8 @@ import tempfile
 import unittest
 import unittest.mock as mock
 from datetime import datetime
+from test import client_context
+from test.utils import AllowListEventListener, NullsTestMixin
 
 import pyarrow
 import pymongo
@@ -26,8 +28,6 @@ from pyarrow import string, struct, timestamp
 from pyarrow.parquet import read_table, write_table
 from pymongo import DESCENDING, MongoClient, WriteConcern
 from pymongo.collection import Collection
-from pytz import timezone
-
 from pymongoarrow.api import Schema, aggregate_arrow_all, find_arrow_all, write
 from pymongoarrow.errors import ArrowWriteError
 from pymongoarrow.monkey import patch_all
@@ -37,9 +37,8 @@ from pymongoarrow.types import (
     Decimal128Type,
     ObjectIdType,
 )
+from pytz import timezone
 
-from test import client_context
-from test.utils import AllowListEventListener, NullsTestMixin
 
 class ArrowApiTestMixin:
     @classmethod
@@ -424,31 +423,33 @@ class ArrowApiTestMixin:
 
     def test_auto_schema_first_list_null(self):
         docs = [
-            {'a': None},
-            {'a': ['str']},
-            {'a': []},
+            {"a": None},
+            {"a": ["str"]},
+            {"a": []},
         ]
         expected = pyarrow.Table.from_pylist(docs)
         self._test_auto_schema_list(docs, expected)
 
     def test_auto_schema_first_list_empty(self):
         docs = [
-            {'a': []},
-            {'a': ['str']},
-            {'a': []},
+            {"a": []},
+            {"a": ["str"]},
+            {"a": []},
         ]
-        expected = pyarrow.Table.from_pylist([
-            {'a': None}, # TODO: We incorrectly set the first empty list to null.
-            {'a': ['str']},
-            {'a': []},
-        ])
+        expected = pyarrow.Table.from_pylist(
+            [
+                {"a": None},  # TODO: We incorrectly set the first empty list to null.
+                {"a": ["str"]},
+                {"a": []},
+            ]
+        )
         self._test_auto_schema_list(docs, expected)
 
     def test_auto_schema_first_list_element_null(self):
         docs = [
-            {'a': None},
-            {'a': [None, None, 'str']},  # Inferred schema should use the first non-null element.
-            {'a': []},
+            {"a": None},
+            {"a": [None, None, "str"]},  # Inferred schema should use the first non-null element.
+            {"a": []},
         ]
         expected = pyarrow.Table.from_pylist(docs)
         self._test_auto_schema_list(docs, expected)
@@ -456,9 +457,9 @@ class ArrowApiTestMixin:
     @unittest.expectedFailure  # TODO: Our inferred value for the first a.b field differs from pyarrow's.
     def test_auto_schema_first_embedded_list_null(self):
         docs = [
-            {'a': {'b': None}},
-            {'a': {'b': ['str']}},
-            {'a': {'b': []}},
+            {"a": {"b": None}},
+            {"a": {"b": ["str"]}},
+            {"a": {"b": []}},
         ]
         expected = pyarrow.Table.from_pylist(docs)
         self._test_auto_schema_list(docs, expected)
@@ -466,9 +467,9 @@ class ArrowApiTestMixin:
     @unittest.expectedFailure  # TODO: Our inferred value for the first a.b field differs from pyarrow's.
     def test_auto_schema_first_embedded_doc_null(self):
         docs = [
-            {'a': {'b': None}},
-            {'a': {'b': 'str'}},
-            {'a': {'b': None}},
+            {"a": {"b": None}},
+            {"a": {"b": "str"}},
+            {"a": {"b": None}},
         ]
         expected = pyarrow.Table.from_pylist(docs)
         self._test_auto_schema_list(docs, expected)

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -470,8 +470,7 @@ class ArrowApiTestMixin:
             {'a': {'b': 'str'}},
             {'a': {'b': None}},
         ]
-        expected = pyarrow.Table.from_pylist()
-        print(expected)
+        expected = pyarrow.Table.from_pylist(docs)
         self._test_auto_schema_list(docs, expected)
 
     def test_auto_schema_heterogeneous(self):


### PR DESCRIPTION
https://jira.mongodb.org/browse/ARROW-158

This fixes the bug in [#136](https://github.com/mongodb-labs/mongo-arrow/issues/136) by properly handling the case where a list or document is empty. When an empty or null list or document is encountered, we skip to examining the next document.

The TODOs are related to how we call append_null() to "backfill" previous records once we discover the schema. Our schema detection differs from pyarrow's from_pylist detection. An example of the difference is in test_auto_schema_first_embedded_list_null:
```
test/test_arrow.py::TestArrowExplicitApi::test_auto_schema_first_embedded_list_null

Expected: pyarrow.Table
a: struct<b: list<item: string>>
  child 0, b: list<item: string>
      child 0, item: string
----
a: [
  -- is_valid: all not null
  -- child 0 type: list<item: string>
[null,["str"],[]]]

Actual  : pyarrow.Table
a: struct<b: list<item: string>>
  child 0, b: list<item: string>
      child 0, item: string
----
a: [
  -- is_valid:  [false,true,true]
  -- child 0 type: list<item: string>
[[],["str"],[]]]

```
I'll open a follow up ticket for that issue. 