### PR TITLE
ARROW-196 Add badges to README

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -1,5 +1,10 @@
 # PyMongoArrow
 
+[![PyPI Version](https://img.shields.io/pypi/v/pymongoarrow)](https://pypi.org/project/pymongoarrow)
+[![Python Versions](https://img.shields.io/pypi/pyversions/pymongoarrow)](https://pypi.org/project/pymongoarrow)
+[![Monthly Downloads](https://static.pepy.tech/badge/pymongoarrow/month)](https://pepy.tech/project/pymongoarrow)
+[![Documentation Status](https://readthedocs.org/projects/mongo-arrow/badge/?version=stable)](http://mongo-arrow.readthedocs.io/en/stable/?badge=stable)
+
 **PyMongoArrow** is a companion library to PyMongo that contains tools
 for loading MongoDB query result sets as Apache Arrow tables, Pandas
 DataFrames or NumPy arrays.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Topic :: Database",
 ]

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -42,7 +42,10 @@ dependencies = [
 dynamic = ["version"]
 
 [project.urls]
-Homepage = "https://github.com/mongodb-labs/mongo-arrow/tree/main/bindings/python"
+Homepage = "https://www.mongodb.org"
+Documentation = "https://mongo-arrow.readthedocs.io"
+Source = "https://github.com/mongodb-labs/mongo-arrow/tree/main/bindings/python"
+Tracker = "https://jira.mongodb.org/projects/ARROW/issues"
 
 [project.optional-dependencies]
 docs = ["sphinx"]


### PR DESCRIPTION
Also updates the Project [URLs](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls) that will be rendered on PyPI since we're removing a couple links from the readme.