### PR TITLE
[ARROW-208] Replaced deprecated pkg_resource with packaging.version

### DIFF
--- a/bindings/python/pymongoarrow/__init__.py
+++ b/bindings/python/pymongoarrow/__init__.py
@@ -17,9 +17,17 @@ import warnings
 
 # We must import pyarrow before attempting to load the Cython module.
 import pyarrow as pa  # noqa: F401
-from packaging.version import parse as _parse_version
 
 from pymongoarrow.version import _MIN_LIBBSON_VERSION, __version__  # noqa: F401
+
+try:
+    from packaging.version import parse as _parse_version
+except ImportError:
+    from distutils.version import LooseVersion as _LooseVersion
+
+    def _parse_version(version):
+        return _LooseVersion(version)
+
 
 try:
     from pymongoarrow.lib import libbson_version

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -105,6 +105,10 @@ filterwarnings = [
   "error",
   # https://github.com/dateutil/dateutil/issues/1314
   "module:datetime.datetime.utc:DeprecationWarning",
+  # https://jira.mongodb.org/browse/ARROW-204
+  'ignore:Passing a BlockManager to DataFrame is deprecated and will raise in a future version. Use public APIs instead.',
+  # https://jira.mongodb.org/browse/ARROW-206
+  'ignore:DatetimeTZBlock is deprecated and will be removed in a future version. Use public APIs instead.'
 ]
 
 [tool.ruff]


### PR DESCRIPTION
The check for a compatible lib_bson version done in `bindings/python/pymongoarrow/_init_.py` throws a DeprecationWarning. This is preventing [PR](https://github.com/mongodb-labs/mongo-arrow/pull/186) for [ARROW-200](https://jira.mongodb.org/browse/ARROW-200) to be merged.

I've cherry-picked the commit from that PR's branch and opened this new one.