### PR TITLE
Support for nested ObjectIDs in polars conversion

### DIFF
--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -313,7 +313,7 @@ def _cast_away_extension_type(field: pa.field) -> pa.field:
     return field_without_extension
 
 
-def _arrow_to_polars(arrow_table: pa.Table) -> pl.DataFrame:
+def _arrow_to_polars(arrow_table: pa.Table):
     """Helper function that converts an Arrow Table to a Polars DataFrame.
 
     Note: Polars lacks ExtensionTypes. We cast them  to their base arrow classes.

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -295,7 +295,7 @@ def aggregate_numpy_all(collection, pipeline, *, schema=None, **kwargs):
     )
 
 
-def _cast_away_extension_type(field):
+def _cast_away_extension_type(field: pa.field) -> pa.field:
     if isinstance(field.type, pa.ExtensionType):
         field_without_extension = pa.field(field.name, field.type.storage_type)
     elif isinstance(field.type, pa.StructType):
@@ -313,7 +313,7 @@ def _cast_away_extension_type(field):
     return field_without_extension
 
 
-def _arrow_to_polars(arrow_table):
+def _arrow_to_polars(arrow_table: pa.Table) -> pl.DataFrame:
     """Helper function that converts an Arrow Table to a Polars DataFrame.
 
     Note: Polars lacks ExtensionTypes. We cast them  to their base arrow classes.

--- a/bindings/python/test/test_polars.py
+++ b/bindings/python/test/test_polars.py
@@ -228,6 +228,8 @@ class TestExplicitPolarsApi(PolarsTestBase):
                 "str": [str(i) for i in range(2)],
                 "int": [i for i in range(2)],
                 "bool": [True, False],
+                "struct": [{"objId": bson.ObjectId().binary, "str1": str(i)} for i in range(2)],
+                "list": [[str(i), str(i + 1)] for i in range(2)],
                 "Binary": [b"1", b"23"],
                 "ObjectId": [bson.ObjectId().binary, bson.ObjectId().binary],
                 "Decimal128": [bson.Decimal128(str(i)).bid for i in range(2)],
@@ -241,9 +243,9 @@ class TestExplicitPolarsApi(PolarsTestBase):
         self.assertEqual(len(arrow_table_in), res.raw_result["insertedCount"])
         df_out = find_polars_all(self.coll, query={}, schema=Schema(arrow_schema))
 
-        # Sanity check: compare with cast_away_extension_types_on_table
-        arrow_cast = api._cast_away_extension_types_on_table(arrow_table_in)
-        assert_frame_equal(df_out, pl.from_arrow(arrow_cast))
+        # Sanity check: compare with _arrow_to_polars
+        df_actual_output = api._arrow_to_polars(arrow_table_in)
+        assert_frame_equal(df_out, df_actual_output)
 
     def test_exceptions_for_unsupported_polar_types(self):
         """Confirm exceptions thrown are expected.


### PR DESCRIPTION
Hi,

_arrow_to_polars currently has no support to cast extension types for nested fields. 
This prohibits ObjectIDs to be read in case they are in nested fields.

I could not manage the conversion with the original code, 
but I found a way to using `arrow_table_without_extensions = arrow_table.cast(schema_without_extensions)` 
to cast the schema of the whole table in one go.

The schema_without_extensions is created recursively from the old schema.
Support for lists is still to be added, should not be that hard, maybe I try tomorrow.

I am not an expert in apache arrow. My world is Pandas and Polars.
I have wrote some unit tests locally to test the code, but I do not feel confident that I have not overlooked
something, so please review carefully. 

#219 

