### PR TITLE
 PYTHON-5058 & PYTHON-5047 Improve testing of publish workflows

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -7,6 +7,8 @@ on:
       - "**"
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron:  '30 5 * * *'
 
 concurrency:
   group: wheels-${{ github.ref }}
@@ -29,7 +31,7 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
         - [ubuntu-20.04, manylinux_x86_64]
-        - [ubuntu-20.04, manylinux_aarch64]
+        - [ubuntu-20.04-arm64, manylinux_aarch64]
         - [macos-14, macosx_*]
         - [windows-2019, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]
@@ -58,12 +60,6 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'bindings/python/pyproject.toml'
           allow-prereleases: true
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
 
       - name: Install pkg-config on MacOS
         if: runner.os == 'macOS'
@@ -152,7 +148,7 @@ jobs:
   publish:
     # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#publishing-the-distribution-to-pypi
     needs: [collect_dist]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ github.event_name != 'pull_request'}}
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -164,4 +160,10 @@ jobs:
         name: all-dist-${{ github.run_id }}
         path: dist/
     - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags/')
       uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Publish package distributions to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        skip-existing: true

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -31,7 +31,7 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
         - [ubuntu-20.04, manylinux_x86_64]
-        - [ubuntu-20.04-arm64, manylinux_aarch64]
+        - [ubuntu-24.04-arm, manylinux_aarch64]
         - [macos-14, macosx_*]
         - [windows-2019, win_amd64]
         python: ["cp39", "cp310", "cp311", "cp312", "cp313"]


### PR DESCRIPTION
Also use the new native `ubuntu-20.04-arm64` instead of relying on QEMU.