### PR TITLE
fix: parallel arrow with differing schema

### DIFF
--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -169,12 +169,12 @@ def find_arrow_all(
     if parallelism == "threads":
         with ThreadPoolExecutor(max_workers=4) as executor:
             results = list(executor.map(lambda args: _process_batch(*args), args_iterable()))
-        return pa.concat_tables(results, promote_options="default")
+        return pa.concat_tables(results, promote_options="permissive")
 
     if parallelism == "processes":
         with multiprocessing.Pool(processes=4) as pool:
             results = pool.starmap(_process_batch, args_iterable())
-        return pa.concat_tables(results, promote_options="default")
+        return pa.concat_tables(results, promote_options="permissive")
 
     context = PyMongoArrowContext(
         schema, codec_options=collection.codec_options, allow_invalid=allow_invalid

--- a/bindings/python/pymongoarrow/lib.pyx
+++ b/bindings/python/pymongoarrow/lib.pyx
@@ -244,7 +244,12 @@ cdef class BuilderManager:
             builder = <_ArrayBuilderBase>self.builder_map.get(full_key, None)
             # If the inferred type was int32 but the same field has an int64 value,
             # re-infer the field's type since int32 is a strict subset of int64.
-            if not self.has_schema and (builder is None or builder.type_marker == BSON_TYPE_INT32 and value_t == BSON_TYPE_INT64):
+            # If builder already existed, avoid ditching previously appended values.
+            if not self.has_schema and builder is not None and builder.type_marker == BSON_TYPE_INT32 and value_t == BSON_TYPE_INT64:
+                old_array = builder.finish().cast('int64')
+                builder = self.get_builder(full_key, value_t, doc_iter, True)
+                builder.append_values(old_array.to_pylist())
+            elif not self.has_schema and builder is None:
                 builder = self.get_builder(full_key, value_t, doc_iter, True)
             if builder is None:
                 continue

--- a/bindings/python/pymongoarrow/lib.pyx
+++ b/bindings/python/pymongoarrow/lib.pyx
@@ -250,7 +250,7 @@ cdef class BuilderManager:
                 builder = self.get_builder(full_key, value_t, doc_iter, True)
                 for val in old_array:
                     if val.is_valid:
-                        (<Int64Builder>builder).builder.get().Append(val)
+                        (<Int64Builder>builder).builder.get().Append(val.as_py())
                     else:
                         (<Int64Builder>builder).builder.get().AppendNull()
             elif not self.has_schema and builder is None:

--- a/bindings/python/pymongoarrow/lib.pyx
+++ b/bindings/python/pymongoarrow/lib.pyx
@@ -248,7 +248,11 @@ cdef class BuilderManager:
             if not self.has_schema and builder is not None and builder.type_marker == BSON_TYPE_INT32 and value_t == BSON_TYPE_INT64:
                 old_array = builder.finish().cast('int64')
                 builder = self.get_builder(full_key, value_t, doc_iter, True)
-                builder.append_values(old_array.to_pylist())
+                for val in old_array:
+                    if val.is_valid:
+                        (<Int64Builder>builder).builder.get().Append(val)
+                    else:
+                        (<Int64Builder>builder).builder.get().AppendNull()
             elif not self.has_schema and builder is None:
                 builder = self.get_builder(full_key, value_t, doc_iter, True)
             if builder is None:

--- a/bindings/python/test/pandas_types/test_int32_overflow.py
+++ b/bindings/python/test/pandas_types/test_int32_overflow.py
@@ -24,7 +24,8 @@ def test_aggregate_pandas_all_schema_inference_int32_avoids_overflow():
     coll.insert_many(
         [
             {"_id": 1, "value": 1},
-            {"_id": 2, "value": 2**40},  # much larger than Int32 max
+            {"_id": 2, "value": None},
+            {"_id": 3, "value": 2**40},  # much larger than Int32 max
         ]
     )
 
@@ -35,7 +36,7 @@ def test_aggregate_pandas_all_schema_inference_int32_avoids_overflow():
 
     df = coll.aggregate_pandas_all(pipeline)
 
-    assert len(df) == 2
+    assert len(df) == 3
     assert df["value"].max() == 2**40
     client.close()
 
@@ -60,6 +61,6 @@ def test_aggregate_pandas_all_explicit_int64_schema_avoids_overflow():
 
     df = coll.aggregate_pandas_all(pipeline, schema=schema)
 
-    assert len(df) == 2
+    assert len(df) == 3
     assert df["value"].max() == 2**40
     client.close()

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -1401,3 +1401,61 @@ class TestFindArrowAllParallelism(unittest.TestCase):
             table_off.equals(table_thread),
             msg=f"tables differ:\n{table_off}\n\n{table_thread}",
         )
+
+    def test_find_multiple_batches_of_different_schema(self):
+        docs = [{"_id": i, "value": i} for i in range(50)] + [
+            {
+                "_id": 50,
+                "value": 2**40,  # Value much larger than Int32 max
+            }
+        ]
+        self.coll.insert_many(docs)
+
+        orig_method = self.coll.find_raw_batches
+
+        def mock_find_raw_batches(*args, **kwargs):
+            kwargs["batch_size"] = 10
+            return orig_method(*args, **kwargs)
+
+        with mock.patch.object(
+            pymongo.collection.Collection,
+            "find_raw_batches",
+            wraps=mock_find_raw_batches,
+        ):
+            table_off = find_arrow_all(
+                self.coll,
+                {},
+                parallelism="off",
+            )
+            table_proc = find_arrow_all(
+                self.coll,
+                {},
+                parallelism="processes",
+            )
+            table_thread = find_arrow_all(
+                self.coll,
+                {},
+                parallelism="threads",
+            )
+
+        self.assertEqual(table_off.num_rows, len(docs))
+        self.assertEqual(table_proc.num_rows, len(docs))
+        self.assertEqual(table_thread.num_rows, len(docs))
+
+        self.assertTrue(
+            table_off.schema.equals(table_proc.schema),
+            msg=f"{table_off.schema} != {table_proc.schema}",
+        )
+        self.assertTrue(
+            table_off.schema.equals(table_thread.schema),
+            msg=f"{table_off.schema} != {table_thread.schema}",
+        )
+
+        self.assertTrue(
+            table_off.equals(table_proc),
+            msg=f"tables differ:\n{table_off}\n\n{table_proc}",
+        )
+        self.assertTrue(
+            table_off.equals(table_thread),
+            msg=f"tables differ:\n{table_off}\n\n{table_thread}",
+        )

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -21,6 +21,8 @@ import unittest
 import unittest.mock as mock
 from datetime import date, datetime, timedelta
 from pathlib import Path
+from test import client_context
+from test.utils import AllowListEventListener, NullsTestMixin
 
 import bson
 import pyarrow as pa
@@ -63,8 +65,6 @@ from pymongoarrow.types import (
     Decimal128Type,
     ObjectIdType,
 )
-from test import client_context
-from test.utils import AllowListEventListener, NullsTestMixin
 
 try:
     import pandas as pd
@@ -1171,28 +1171,26 @@ class ArrowApiTestMixin:
                 if isinstance(arrow_value, decimal.Decimal):
                     assert (
                         Decimal128(arrow_value).to_decimal() == Decimal128(mongo_value).to_decimal()
-                    ), (
-                        f"Precision loss in decimal field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
-                    )
+                    ), f"Precision loss in decimal field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
                 elif isinstance(arrow_value, (np.datetime64, pd.Timestamp, datetime)):
                     arrow_value_rounded = pd.Timestamp(arrow_value).round(
                         "ms"
                     )  # Round to milliseconds
-                    assert arrow_value_rounded.to_pydatetime() == mongo_value, (
-                        f"Datetime mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value_rounded}, got {mongo_value}."
-                    )
+                    assert (
+                        arrow_value_rounded.to_pydatetime() == mongo_value
+                    ), f"Datetime mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value_rounded}, got {mongo_value}."
                 elif isinstance(arrow_value, (list, np.ndarray)):
-                    assert arrow_value == mongo_value, (
-                        f"List mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
-                    )
+                    assert (
+                        arrow_value == mongo_value
+                    ), f"List mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
                 elif isinstance(arrow_value, timedelta):
-                    assert arrow_value == timedelta(seconds=mongo_value), (
-                        f"Timedelta mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
-                    )
+                    assert (
+                        arrow_value == timedelta(seconds=mongo_value)
+                    ), f"Timedelta mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
                 else:
-                    assert arrow_value == mongo_value, (
-                        f"Value mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
-                    )
+                    assert (
+                        arrow_value == mongo_value
+                    ), f"Value mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
 
     def test_all_types(self):
         """

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -21,8 +21,6 @@ import unittest
 import unittest.mock as mock
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from test import client_context
-from test.utils import AllowListEventListener, NullsTestMixin
 
 import bson
 import pyarrow as pa
@@ -65,6 +63,8 @@ from pymongoarrow.types import (
     Decimal128Type,
     ObjectIdType,
 )
+from test import client_context
+from test.utils import AllowListEventListener, NullsTestMixin
 
 try:
     import pandas as pd
@@ -1171,26 +1171,28 @@ class ArrowApiTestMixin:
                 if isinstance(arrow_value, decimal.Decimal):
                     assert (
                         Decimal128(arrow_value).to_decimal() == Decimal128(mongo_value).to_decimal()
-                    ), f"Precision loss in decimal field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
+                    ), (
+                        f"Precision loss in decimal field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
+                    )
                 elif isinstance(arrow_value, (np.datetime64, pd.Timestamp, datetime)):
                     arrow_value_rounded = pd.Timestamp(arrow_value).round(
                         "ms"
                     )  # Round to milliseconds
-                    assert (
-                        arrow_value_rounded.to_pydatetime() == mongo_value
-                    ), f"Datetime mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value_rounded}, got {mongo_value}."
+                    assert arrow_value_rounded.to_pydatetime() == mongo_value, (
+                        f"Datetime mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value_rounded}, got {mongo_value}."
+                    )
                 elif isinstance(arrow_value, (list, np.ndarray)):
-                    assert (
-                        arrow_value == mongo_value
-                    ), f"List mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
+                    assert arrow_value == mongo_value, (
+                        f"List mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
+                    )
                 elif isinstance(arrow_value, timedelta):
-                    assert (
-                        arrow_value == timedelta(seconds=mongo_value)
-                    ), f"Timedelta mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
+                    assert arrow_value == timedelta(seconds=mongo_value), (
+                        f"Timedelta mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
+                    )
                 else:
-                    assert (
-                        arrow_value == mongo_value
-                    ), f"Value mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
+                    assert arrow_value == mongo_value, (
+                        f"Value mismatch in field '{column_name}' for row {row_idx}. Expected {arrow_value}, got {mongo_value}."
+                    )
 
     def test_all_types(self):
         """
@@ -1403,9 +1405,9 @@ class TestFindArrowAllParallelism(unittest.TestCase):
         )
 
     def test_find_multiple_batches_of_different_schema(self):
-        docs = [{"_id": i, "value": i} for i in range(50)] + [
+        docs = [{"_id": i, "value": i} for i in range(10)] + [
             {
-                "_id": 50,
+                "_id": 10,
                 "value": 2**40,  # Value much larger than Int32 max
             }
         ]
@@ -1414,7 +1416,7 @@ class TestFindArrowAllParallelism(unittest.TestCase):
         orig_method = self.coll.find_raw_batches
 
         def mock_find_raw_batches(*args, **kwargs):
-            kwargs["batch_size"] = 10
+            kwargs["batch_size"] = 2
             return orig_method(*args, **kwargs)
 
         with mock.patch.object(


### PR DESCRIPTION
## Changes in this PR
<!-- What changes did you make to the code? What new APIs (public or private) were added, removed, or edited to generate
the desired outcome explained in the above summary? -->
#384 introduces "parallel batch processing for PyMongoArrow" and #383 handles a case where the inferred schema should be promoted to Int64 (if previously Int32). However, they did not work together on the edge case where not all batches were promoted.

While I was creating this PR, I found a bug where no parallelism was ditching existing values:

<details><summary>Error</summary>
<p>

```
>       self.assertTrue(
            table_off.equals(table_proc),
            msg=f"tables differ:\n{table_off}\n\n{table_proc}",
        )
E       AssertionError: False is not true : tables differ:
E       pyarrow.Table
E       _id: int32
E       value: int64
E       ----
E       _id: [[0,1,2,3,4,...,46,47,48,49,50]]
E       value: [[null,null,null,null,null,...,null,null,null,null,1099511627776]]
E
E       pyarrow.Table
E       _id: int32
E       value: int64
E       ----
E       _id: [[0,1,2,3,4,5,6,7,8,9],[10,11,12,13,14,15,16,17,18,19],...,[40,41,42,43,44,45,46,47,48,49],[50]]
E       value: [[0,1,2,3,4,5,6,7,8,9],[10,11,12,13,14,15,16,17,18,19],...,[40,41,42,43,44,45,46,47,48,49],[1099511627776]]

test/test_arrow.py:1467: AssertionError
```

</p>
</details>

This was because the builder was being filled with values and then a new one was constructed, replacing all values.

This closes #390  

## Test Plan
<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why.
All code should be tested in some way – so please list what your validation strategy was. -->
I tested this in two ways. I added the unit tests and I ran this against a real cluster I was having issues with.

## Checklist
<!-- Do not delete the items provided on this checklist. -->

### Checklist for Author
- [x] Did you update the changelog (if necessary)?
 		I did not update the changelog because this fix still fits inside all the new changes
- [x] Is there test coverage?
- [ ] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
