### PR TITLE
docs: add pixi installation instructions to README

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -67,6 +67,29 @@ python -m pip install pandas
 Note: `pymongoarrow` is not supported or tested on big-endian systems
 (e.g. Linux s390x).
 
+### Installing in a pixi environment
+
+[Pixi](https://pixi.sh) is a conda-compatible package manager. PyMongoArrow is
+not currently available on conda-forge, so install it from PyPI using the
+`--pypi` flag:
+
+```bash
+pixi add python
+pixi add --pypi pymongoarrow pymongo pyarrow
+```
+
+Your `pixi.toml` will look like:
+
+```toml
+[dependencies]
+python = ">=3.x"
+
+[pypi-dependencies]
+pymongoarrow = ">=1.13.0, <2"
+pymongo = ">=4.0, <5"
+pyarrow = ">=14.0"
+```
+
 ## Development Install
 
 See the instructions in the [Contributing Guide][./CONTRIBUTING.md]


### PR DESCRIPTION
## Summary
- Adds a "Installing in a pixi environment" section to `bindings/python/README.md`
- Documents that `pymongoarrow` is not on conda-forge and must be installed via `--pypi`
- Provides example CLI commands and a sample `pixi.toml`

## Test Plan
- [x] Manually verified: `pixi add python && pixi add --pypi pymongoarrow pymongo pyarrow` installs successfully
- [x] Roundtrip test (`find_arrow_all`) passed in the pixi environment
- [x] Documentation-only change; no code modified

Closes INTPYTHON-685