### PR TITLE
INTPYTHON-951: Parallel find_all on empty result fails

### DIFF
--- a/bindings/python/CONTRIBUTING.md
+++ b/bindings/python/CONTRIBUTING.md
@@ -27,7 +27,6 @@ PyMongoArrow uses [Ruff](https://docs.astral.sh/ruff/) for formatting and lintin
 -   Write tests and make sure they pass (make sure you have a mongod
     running on the default port, then execute `just test` from the cmd
     line to run the test suite).
--   Add yourself to doc/contributors.rst `:)`
 
 ## Authoring a Pull Request
 

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -110,6 +110,7 @@ def _process_batch(schema, codec_options, allow_invalid, batch):
 
     return context.finish()
 
+
 def _concat_or_empty(results, *, schema, codec_options, allow_invalid):
     if results:
         return pa.concat_tables(results, promote_options="permissive")
@@ -120,6 +121,7 @@ def _concat_or_empty(results, *, schema, codec_options, allow_invalid):
         allow_invalid=allow_invalid,
     )
     return context.finish()
+
 
 Parallelism = Literal["threads", "processes", "off"]
 

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -110,6 +110,16 @@ def _process_batch(schema, codec_options, allow_invalid, batch):
 
     return context.finish()
 
+def _concat_or_empty(results, *, schema, codec_options, allow_invalid):
+    if results:
+        return pa.concat_tables(results, promote_options="permissive")
+
+    context = PyMongoArrowContext(
+        schema,
+        codec_options=codec_options,
+        allow_invalid=allow_invalid,
+    )
+    return context.finish()
 
 Parallelism = Literal["threads", "processes", "off"]
 
@@ -169,12 +179,22 @@ def find_arrow_all(
     if parallelism == "threads":
         with ThreadPoolExecutor(max_workers=4) as executor:
             results = list(executor.map(lambda args: _process_batch(*args), args_iterable()))
-        return pa.concat_tables(results, promote_options="permissive")
+        return _concat_or_empty(
+            results,
+            schema=schema,
+            codec_options=collection.codec_options,
+            allow_invalid=allow_invalid,
+        )
 
     if parallelism == "processes":
         with multiprocessing.Pool(processes=4) as pool:
             results = pool.starmap(_process_batch, args_iterable())
-        return pa.concat_tables(results, promote_options="permissive")
+        return _concat_or_empty(
+            results,
+            schema=schema,
+            codec_options=collection.codec_options,
+            allow_invalid=allow_invalid,
+        )
 
     context = PyMongoArrowContext(
         schema, codec_options=collection.codec_options, allow_invalid=allow_invalid

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -1459,7 +1459,7 @@ class TestFindArrowAllParallelism(unittest.TestCase):
             table_off.equals(table_thread),
             msg=f"tables differ:\n{table_off}\n\n{table_thread}",
         )
-    
+
     def _assert_empty_arrow_table(self, table, expected_schema=None):
         self.assertEqual(table.num_rows, 0)
         if expected_schema is None:

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -1459,3 +1459,89 @@ class TestFindArrowAllParallelism(unittest.TestCase):
             table_off.equals(table_thread),
             msg=f"tables differ:\n{table_off}\n\n{table_thread}",
         )
+    
+    def _assert_empty_arrow_table(self, table, expected_schema=None):
+        self.assertEqual(table.num_rows, 0)
+        if expected_schema is None:
+            self.assertEqual(table.num_columns, 0)
+        else:
+            self.assertTrue(
+                table.schema.equals(expected_schema),
+                msg=f"{table.schema} != {expected_schema}",
+            )
+
+    def test_find_arrow_all_threads_empty_query_returns_empty_table(self):
+        self.coll.insert_one({"_id": 1, "value": 1})
+
+        expected = find_arrow_all(
+            self.coll,
+            {"_id": 999},
+            parallelism="off",
+        )
+        table = find_arrow_all(
+            self.coll,
+            {"_id": 999},
+            parallelism="threads",
+        )
+
+        self._assert_empty_arrow_table(table, expected.schema)
+        self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")
+
+    def test_find_arrow_all_processes_empty_query_returns_empty_table(self):
+        self.coll.insert_one({"_id": 1, "value": 1})
+
+        expected = find_arrow_all(
+            self.coll,
+            {"_id": 999},
+            parallelism="off",
+        )
+        table = find_arrow_all(
+            self.coll,
+            {"_id": 999},
+            parallelism="processes",
+        )
+
+        self._assert_empty_arrow_table(table, expected.schema)
+        self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")
+
+    def test_find_arrow_all_threads_empty_query_with_schema_returns_empty_table(self):
+        self.coll.insert_one({"_id": 1, "value": 1})
+
+        schema = Schema({"_id": int, "value": int})
+
+        expected = find_arrow_all(
+            self.coll,
+            {"_id": 999},
+            schema=schema,
+            parallelism="off",
+        )
+        table = find_arrow_all(
+            self.coll,
+            {"_id": 999},
+            schema=schema,
+            parallelism="threads",
+        )
+
+        self._assert_empty_arrow_table(table, expected.schema)
+        self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")
+
+    def test_find_arrow_all_processes_empty_query_with_schema_returns_empty_table(self):
+        self.coll.insert_one({"_id": 1, "value": 1})
+
+        schema = Schema({"_id": int, "value": int})
+
+        expected = find_arrow_all(
+            self.coll,
+            {"_id": 999},
+            schema=schema,
+            parallelism="off",
+        )
+        table = find_arrow_all(
+            self.coll,
+            {"_id": 999},
+            schema=schema,
+            parallelism="processes",
+        )
+
+        self._assert_empty_arrow_table(table, expected.schema)
+        self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -1470,78 +1470,27 @@ class TestFindArrowAllParallelism(unittest.TestCase):
                 msg=f"{table.schema} != {expected_schema}",
             )
 
-    def test_find_arrow_all_threads_empty_query_returns_empty_table(self):
+    def test_find_arrow_all_empty_query_returns_empty_table(self):
         self.coll.insert_one({"_id": 1, "value": 1})
 
-        expected = find_arrow_all(
-            self.coll,
-            {"_id": 999},
-            parallelism="off",
-        )
-        table = find_arrow_all(
-            self.coll,
-            {"_id": 999},
-            parallelism="threads",
-        )
+        for schema in (None, Schema({"_id": int, "value": int})):
+            expected = find_arrow_all(
+                self.coll,
+                {"_id": 999},
+                schema=schema,
+                parallelism="off",
+            )
 
-        self._assert_empty_arrow_table(table, expected.schema)
-        self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")
-
-    def test_find_arrow_all_processes_empty_query_returns_empty_table(self):
-        self.coll.insert_one({"_id": 1, "value": 1})
-
-        expected = find_arrow_all(
-            self.coll,
-            {"_id": 999},
-            parallelism="off",
-        )
-        table = find_arrow_all(
-            self.coll,
-            {"_id": 999},
-            parallelism="processes",
-        )
-
-        self._assert_empty_arrow_table(table, expected.schema)
-        self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")
-
-    def test_find_arrow_all_threads_empty_query_with_schema_returns_empty_table(self):
-        self.coll.insert_one({"_id": 1, "value": 1})
-
-        schema = Schema({"_id": int, "value": int})
-
-        expected = find_arrow_all(
-            self.coll,
-            {"_id": 999},
-            schema=schema,
-            parallelism="off",
-        )
-        table = find_arrow_all(
-            self.coll,
-            {"_id": 999},
-            schema=schema,
-            parallelism="threads",
-        )
-
-        self._assert_empty_arrow_table(table, expected.schema)
-        self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")
-
-    def test_find_arrow_all_processes_empty_query_with_schema_returns_empty_table(self):
-        self.coll.insert_one({"_id": 1, "value": 1})
-
-        schema = Schema({"_id": int, "value": int})
-
-        expected = find_arrow_all(
-            self.coll,
-            {"_id": 999},
-            schema=schema,
-            parallelism="off",
-        )
-        table = find_arrow_all(
-            self.coll,
-            {"_id": 999},
-            schema=schema,
-            parallelism="processes",
-        )
-
-        self._assert_empty_arrow_table(table, expected.schema)
-        self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")
+            for parallelism in ("threads", "processes"):
+                with self.subTest(
+                    parallelism=parallelism,
+                    schema_provided=schema is not None,
+                ):
+                    table = find_arrow_all(
+                        self.coll,
+                        {"_id": 999},
+                        schema=schema,
+                        parallelism=parallelism,
+                    )
+                    self._assert_empty_arrow_table(table, expected.schema)
+                    self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")


### PR DESCRIPTION
[INTPYTHON-951](https://jira.mongodb.org/browse/INTPYTHON-951)

## Changes in this PR
Addresses bug noted in issue #398. Previously, when parallel `find_all` was used and the query returned no documents, `pa.concat_tables` is called with an empty list and results in `ArrowInvalid: Must pass at least one table`. The change updates the parallel code paths to return an empty Arrow table instead of attempting to concatenate zero tables.

## Test Plan
I added tests in `test/test_arrow.py` for empty queries across both parallelism modes, with and without an explicit schema.

## Checklist

### Checklist for Author
- [n/a] Did you update the changelog (if necessary)?
- [yes] Is there test coverage?
- [n/a] Is any followup work tracked in a JIRA ticket? If so, add link(s).

### Checklist for Reviewer
- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
