### PR TITLE
Prep for v1.13.1 release

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ---
 
-# Changes in Version 1.13.0 (2026/XX/XX)
+# Changes in Version 1.13.0 (2026/03/12)
 
 - Add Polars Extension Type support for the BSON Binary, Code, ObjectId, and Decimal128 types.
 - Add ability to use threads or multiprocesses in `find_arrow_all`, `find_pandas_all`,
@@ -11,6 +11,7 @@
   `find_arrow_all(collection, {}, parallelism="threads")` would utilize threads. Other values of
   `parallelism` are `"off"` (default) and `"processes"`.
 - Fix a bug where schema inference for integer fields could produce an overflow error if the first value in the field fit within the int32 range but later values did not.
+- Fix a bug where parallel batch processing would fail when different batches had different inferred schemas.
 
 
 # Changes in Version 1.12.0 (2026/01/26)

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -3,6 +3,11 @@
 
 ---
 
+# Changes in Version 1.13.1 (2026/05/27)
+
+- Fixes bug where if parallel `find_all` on empty results failed due to trying to concat no tables. Now, the concat is skipped on empty results.
+
+
 # Changes in Version 1.13.0 (2026/03/12)
 
 - Add Polars Extension Type support for the BSON Binary, Code, ObjectId, and Decimal128 types.

--- a/bindings/python/CONTRIBUTING.md
+++ b/bindings/python/CONTRIBUTING.md
@@ -27,7 +27,6 @@ PyMongoArrow uses [Ruff](https://docs.astral.sh/ruff/) for formatting and lintin
 -   Write tests and make sure they pass (make sure you have a mongod
     running on the default port, then execute `just test` from the cmd
     line to run the test suite).
--   Add yourself to doc/contributors.rst `:)`
 
 ## Authoring a Pull Request
 

--- a/bindings/python/pymongoarrow/api.py
+++ b/bindings/python/pymongoarrow/api.py
@@ -111,6 +111,18 @@ def _process_batch(schema, codec_options, allow_invalid, batch):
     return context.finish()
 
 
+def _concat_or_empty(results, *, schema, codec_options, allow_invalid):
+    if results:
+        return pa.concat_tables(results, promote_options="permissive")
+
+    context = PyMongoArrowContext(
+        schema,
+        codec_options=codec_options,
+        allow_invalid=allow_invalid,
+    )
+    return context.finish()
+
+
 Parallelism = Literal["threads", "processes", "off"]
 
 
@@ -169,12 +181,22 @@ def find_arrow_all(
     if parallelism == "threads":
         with ThreadPoolExecutor(max_workers=4) as executor:
             results = list(executor.map(lambda args: _process_batch(*args), args_iterable()))
-        return pa.concat_tables(results, promote_options="permissive")
+        return _concat_or_empty(
+            results,
+            schema=schema,
+            codec_options=collection.codec_options,
+            allow_invalid=allow_invalid,
+        )
 
     if parallelism == "processes":
         with multiprocessing.Pool(processes=4) as pool:
             results = pool.starmap(_process_batch, args_iterable())
-        return pa.concat_tables(results, promote_options="permissive")
+        return _concat_or_empty(
+            results,
+            schema=schema,
+            codec_options=collection.codec_options,
+            allow_invalid=allow_invalid,
+        )
 
     context = PyMongoArrowContext(
         schema, codec_options=collection.codec_options, allow_invalid=allow_invalid

--- a/bindings/python/pymongoarrow/version.py
+++ b/bindings/python/pymongoarrow/version.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.13.0.dev0"
+__version__ = "1.13.0"
 
 _MIN_LIBBSON_VERSION = "1.23.1"

--- a/bindings/python/pymongoarrow/version.py
+++ b/bindings/python/pymongoarrow/version.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.13.0"
+__version__ = "1.13.1"
 
 _MIN_LIBBSON_VERSION = "1.23.1"

--- a/bindings/python/test/test_arrow.py
+++ b/bindings/python/test/test_arrow.py
@@ -1459,3 +1459,38 @@ class TestFindArrowAllParallelism(unittest.TestCase):
             table_off.equals(table_thread),
             msg=f"tables differ:\n{table_off}\n\n{table_thread}",
         )
+
+    def _assert_empty_arrow_table(self, table, expected_schema=None):
+        self.assertEqual(table.num_rows, 0)
+        if expected_schema is None:
+            self.assertEqual(table.num_columns, 0)
+        else:
+            self.assertTrue(
+                table.schema.equals(expected_schema),
+                msg=f"{table.schema} != {expected_schema}",
+            )
+
+    def test_find_arrow_all_empty_query_returns_empty_table(self):
+        self.coll.insert_one({"_id": 1, "value": 1})
+
+        for schema in (None, Schema({"_id": int, "value": int})):
+            expected = find_arrow_all(
+                self.coll,
+                {"_id": 999},
+                schema=schema,
+                parallelism="off",
+            )
+
+            for parallelism in ("threads", "processes"):
+                with self.subTest(
+                    parallelism=parallelism,
+                    schema_provided=schema is not None,
+                ):
+                    table = find_arrow_all(
+                        self.coll,
+                        {"_id": 999},
+                        schema=schema,
+                        parallelism=parallelism,
+                    )
+                    self._assert_empty_arrow_table(table, expected.schema)
+                    self.assertTrue(table.equals(expected), msg=f"{table} != {expected}")


### PR DESCRIPTION
# Changes in Version 1.13.1 (2026/05/27)

- Fixes bug where if parallel `find_all` on empty results failed due to trying to concat no tables. Now, the concat is skipped on empty results.